### PR TITLE
[Feat/convert-component animation] 변환 페이지 내 컴포넌트 애니메이션 동작

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,9 +1,9 @@
 module.exports = {
-  printWidth: 100,
+  printWidth: 150,
   parser: 'typescript',
   singleQuote: true,
   useTabs: false, // Indent lines with tabs instead of spaces.
   printWidth: 80, // Specify the length of line that the printer will wrap on.
   tabWidth: 2, // Specify the number of spaces per indentation-level.
-  trailingComma: 'es5'
+  trailingComma: 'es5',
 };

--- a/src/component/CharacterBox.tsx
+++ b/src/component/CharacterBox.tsx
@@ -86,7 +86,6 @@ interface Props {
   data: string;
   onScroll: (scrollTop: number) => void;
   scrollTop: number;
-  isWrite: boolean;
   temp: string[];
   setTemp: (temp: string[]) => void;
   onMoveScroll: () => void;
@@ -193,7 +192,7 @@ const CharacterBox = ({
     onMoveScroll();
     setTimeout(() => {
       startAnimation(controlScripts);
-    }, 2000);
+    }, 1000);
   };
 
   return (

--- a/src/component/CharacterBox.tsx
+++ b/src/component/CharacterBox.tsx
@@ -227,7 +227,11 @@ const CharacterBox = ({
             </TutorialText>
           </TutorialBox>
           {/* 소설 작성 후 버튼 활성화 */}
-          <ConvertButton onClick={handleClick} isWrite={step[0]}>
+          <ConvertButton
+            disabled={step[0]}
+            onClick={handleClick}
+            isWrite={step[0]}
+          >
             등장인물 인식
           </ConvertButton>
         </ConvertBoxWrapper>

--- a/src/component/CharacterBox.tsx
+++ b/src/component/CharacterBox.tsx
@@ -10,38 +10,96 @@ import {
   TutorialTitle,
   TutorialText,
   HighlightedText,
-  ConvertButton
+  ConvertButton,
 } from '../styles/convertBoxStyles';
 
 // dummy data (입력 데이터 예시)
 const inputSentences = [
-  ['왕자는', '너무도', '친숙한', '라푼젤의', '목소리가', '들리자', '앞으로', '나아갔어요.'],
-  ['왕자는', '다가오자마자', '라푼젤은', '왕자를', '알아보고', '목을', '감싸며', '안겨서', '울었어요.'],
+  [
+    '왕자는',
+    '너무도',
+    '친숙한',
+    '라푼젤의',
+    '목소리가',
+    '들리자',
+    '앞으로',
+    '나아갔어요.',
+  ],
+  [
+    '왕자는',
+    '다가오자마자',
+    '라푼젤은',
+    '왕자를',
+    '알아보고',
+    '목을',
+    '감싸며',
+    '안겨서',
+    '울었어요.',
+  ],
   ['그때', '라푼젤의', '눈물', '두', '방울이', '그의', '눈들을', '적셨어요.'],
-  ['그러자', '왕자의', '시력이', '점점', '밝아지며', '급기야', '예전처럼', '라푼젤을', '볼', '수', '있게', '되었어요.'],
+  [
+    '그러자',
+    '왕자의',
+    '시력이',
+    '점점',
+    '밝아지며',
+    '급기야',
+    '예전처럼',
+    '라푼젤을',
+    '볼',
+    '수',
+    '있게',
+    '되었어요.',
+  ],
   ['왕자는', '라푼젤을', '데리고', '자신의', '왕국으로', '돌아갔어요.'],
   ['왕국에서도', '왕자의', '일행을', '대환영해주었어요.'],
-  ['이후', '그들은', '행복해하고', '만족해하며', '오래토록', '잘', '살았답니다.'],
+  [
+    '이후',
+    '그들은',
+    '행복해하고',
+    '만족해하며',
+    '오래토록',
+    '잘',
+    '살았답니다.',
+  ],
 ];
 // dummy data (하이라이트할 결과 데이터 예시)
 const resultData1 = [
   { text: '왕자는', sent_id: 0, start_eid: 0, end_eid: 0 },
-  { text: '그를', sent_id: 1, start_eid: 3, end_eid: 3 }
+  { text: '그를', sent_id: 1, start_eid: 3, end_eid: 3 },
 ];
 const resultData = [
-  [{ text: '왕자는', sent_id: 0, start_eid: 0, end_eid: 0 },
-  { text: '그를', sent_id: 1, start_eid: 3, end_eid: 3 }],
-  [{ text: '라푼젤의', sent_id: 0, start_eid: 3, end_eid: 3 },
-    { text: '라푼젤을', sent_id: 4, start_eid: 1, end_eid: 1 }]  
+  [
+    { text: '왕자는', sent_id: 0, start_eid: 0, end_eid: 0 },
+    { text: '그를', sent_id: 1, start_eid: 3, end_eid: 3 },
+  ],
+  [
+    { text: '라푼젤의', sent_id: 0, start_eid: 3, end_eid: 3 },
+    { text: '라푼젤을', sent_id: 4, start_eid: 1, end_eid: 1 },
+  ],
 ];
 
 interface Props {
   data: string;
   onScroll: (scrollTop: number) => void;
   scrollTop: number;
+  isWrite: boolean;
+  temp: string[];
+  setTemp: (temp: string[]) => void;
+  step: boolean[];
+  setStep: (step: boolean[]) => void;
 }
 
-const CharacterBox = ({ data, onScroll, scrollTop }: Props) => {
+const CharacterBox = ({
+  data,
+  onScroll,
+  scrollTop,
+  isWrite,
+  step,
+  setStep,
+  temp,
+  setTemp,
+}: Props) => {
   const [characterList, setCharacterList] = useState(['왕자', '라푼젤']);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
@@ -49,21 +107,34 @@ const CharacterBox = ({ data, onScroll, scrollTop }: Props) => {
   const renderWords = () => {
     return inputSentences.map((sentence, sentIndex) =>
       sentence.map((word, eid) => {
-        const highlightInfo = resultData.find(dataGroup =>
-          dataGroup.some(data => data.sent_id === sentIndex && data.start_eid <= eid && data.end_eid >= eid)
+        const highlightInfo = resultData.find((dataGroup) =>
+          dataGroup.some(
+            (data) =>
+              data.sent_id === sentIndex &&
+              data.start_eid <= eid &&
+              data.end_eid >= eid
+          )
         );
 
         if (!highlightInfo) {
           return (
-            <HighlightedWord key={`${sentIndex}-${eid}`} highlightColor="transparent">
+            <HighlightedWord
+              key={`${sentIndex}-${eid}`}
+              highlightColor="transparent"
+            >
               {word}&nbsp;
             </HighlightedWord>
           );
         }
 
         // highlightInfo가 포함된 groupIndex 찾기
-        const groupIndex = resultData.findIndex(dataGroup =>
-          dataGroup.some(data => data.sent_id === sentIndex && data.start_eid <= eid && data.end_eid >= eid)
+        const groupIndex = resultData.findIndex((dataGroup) =>
+          dataGroup.some(
+            (data) =>
+              data.sent_id === sentIndex &&
+              data.start_eid <= eid &&
+              data.end_eid >= eid
+          )
         );
 
         // groupIndex에 따라 색상 설정
@@ -71,7 +142,10 @@ const CharacterBox = ({ data, onScroll, scrollTop }: Props) => {
 
         return (
           <>
-            <HighlightedWord key={`${sentIndex}-${eid}`} highlightColor={highlightColor}>
+            <HighlightedWord
+              key={`${sentIndex}-${eid}`}
+              highlightColor={highlightColor}
+            >
               {word}
             </HighlightedWord>
             &nbsp;
@@ -87,7 +161,7 @@ const CharacterBox = ({ data, onScroll, scrollTop }: Props) => {
 
     // groupIndex가 colors 배열의 길이를 넘어가면 추가 색상은 랜덤하게 반환하도록 설정
     if (groupIndex >= colors.length) {
-      return `#${Math.floor(Math.random()*16777215).toString(16)}`; // 랜덤 색상 생성
+      return `#${Math.floor(Math.random() * 16777215).toString(16)}`; // 랜덤 색상 생성
     }
 
     return colors[groupIndex];
@@ -106,16 +180,20 @@ const CharacterBox = ({ data, onScroll, scrollTop }: Props) => {
     }
   };
 
+  const handleClick = () => {
+    step[1] = true;
+    setStep([...step]);
+    temp[0] = 'data';
+    setTemp([...temp]);
+  };
+
   return (
     <>
       {data ? (
         <ConvertBoxWrapper>
           <TitleText>등장인물 인식 결과</TitleText>
-          <ContentBox style={{height: '27rem'}}>
-            <ScrollText
-              ref={scrollAreaRef}
-              onScroll={handleScroll}
-            >
+          <ContentBox style={{ height: '27rem' }}>
+            <ScrollText ref={scrollAreaRef} onScroll={handleScroll}>
               {renderWords()}
             </ScrollText>
           </ContentBox>
@@ -127,16 +205,21 @@ const CharacterBox = ({ data, onScroll, scrollTop }: Props) => {
           <TutorialBox>
             <TutorialTitle>#1 소설 원고 입력하기</TutorialTitle>
             <TutorialText>
-              1. 좌측에 소설 원고를 작성합니다.<br />
-              2. <HighlightedText>등장인물 인식 버튼</HighlightedText>을 누릅니다.<br />
+              1. 좌측에 소설 원고를 작성합니다.
+              <br />
+              2. <HighlightedText>등장인물 인식 버튼</HighlightedText>을
+              누릅니다.
+              <br />
               3. 등장인물 목록을 확인하고 수정합니다.
             </TutorialText>
           </TutorialBox>
-          <ConvertButton>등장인물 인식</ConvertButton>
+          <ConvertButton onClick={handleClick} isWrite={isWrite}>
+            등장인물 인식
+          </ConvertButton>
         </ConvertBoxWrapper>
       )}
     </>
-  )
+  );
 };
 
 export default CharacterBox;
@@ -147,5 +230,5 @@ interface HighlightedWordProps {
 
 const HighlightedWord = styled.p<HighlightedWordProps>`
   display: inline;
-  background-color: ${props => props.highlightColor};
+  background-color: ${(props) => props.highlightColor};
 `;

--- a/src/component/CharacterBox.tsx
+++ b/src/component/CharacterBox.tsx
@@ -89,6 +89,7 @@ interface Props {
   temp: string[];
   setTemp: (temp: string[]) => void;
   onMoveScroll: () => void;
+  setSelect: (select: number) => void;
 }
 
 const CharacterBox = ({
@@ -98,6 +99,7 @@ const CharacterBox = ({
   temp,
   setTemp,
   onMoveScroll,
+  setSelect,
 }: Props) => {
   const [characterList, setCharacterList] = useState(['왕자', '라푼젤']);
   const { controlScripts, startAnimation } = useAnimationContext(); // 변환 컴포넌트 애니메이션 컨트롤
@@ -187,6 +189,9 @@ const CharacterBox = ({
     setStep([...step]);
     temp[0] = 'data';
     setTemp([...temp]);
+
+    // 인디케이터 select 값 변경
+    setSelect(1); // 대본으로 이동
 
     // 애니메이션
     onMoveScroll();

--- a/src/component/CharacterBox.tsx
+++ b/src/component/CharacterBox.tsx
@@ -14,6 +14,7 @@ import {
 } from '../styles/convertBoxStyles';
 import { useAnimationContext } from '../context/animationContext';
 import { motion } from 'framer-motion';
+import { useConvertStep } from '../context/convertStepContext';
 
 // dummy data (입력 데이터 예시)
 const inputSentences = [
@@ -88,8 +89,6 @@ interface Props {
   isWrite: boolean;
   temp: string[];
   setTemp: (temp: string[]) => void;
-  step: boolean[];
-  setStep: (step: boolean[]) => void;
   onMoveScroll: () => void;
 }
 
@@ -97,9 +96,6 @@ const CharacterBox = ({
   data,
   onScroll,
   scrollTop,
-  isWrite,
-  step,
-  setStep,
   temp,
   setTemp,
   onMoveScroll,
@@ -107,6 +103,7 @@ const CharacterBox = ({
   const [characterList, setCharacterList] = useState(['왕자', '라푼젤']);
   const { controlScripts, startAnimation } = useAnimationContext(); // 변환 컴포넌트 애니메이션 컨트롤
   const scrollAreaRef = useRef<HTMLDivElement>(null);
+  const { step, setStep } = useConvertStep(); // 변환 단계 관리
 
   // 각 어절을 div로 렌더링
   const renderWords = () => {
@@ -225,7 +222,8 @@ const CharacterBox = ({
               3. 등장인물 목록을 확인하고 수정합니다.
             </TutorialText>
           </TutorialBox>
-          <ConvertButton onClick={handleClick} isWrite={isWrite}>
+          {/* 소설 작성 후 버튼 활성화 */}
+          <ConvertButton onClick={handleClick} isWrite={step[0]}>
             등장인물 인식
           </ConvertButton>
         </ConvertBoxWrapper>

--- a/src/component/CharacterBox.tsx
+++ b/src/component/CharacterBox.tsx
@@ -12,6 +12,8 @@ import {
   HighlightedText,
   ConvertButton,
 } from '../styles/convertBoxStyles';
+import { useAnimationContext } from '../context/animationContext';
+import { motion } from 'framer-motion';
 
 // dummy data (입력 데이터 예시)
 const inputSentences = [
@@ -88,6 +90,7 @@ interface Props {
   setTemp: (temp: string[]) => void;
   step: boolean[];
   setStep: (step: boolean[]) => void;
+  onMoveScroll: () => void;
 }
 
 const CharacterBox = ({
@@ -99,8 +102,10 @@ const CharacterBox = ({
   setStep,
   temp,
   setTemp,
+  onMoveScroll,
 }: Props) => {
   const [characterList, setCharacterList] = useState(['왕자', '라푼젤']);
+  const { controlScripts, startAnimation } = useAnimationContext(); // 변환 컴포넌트 애니메이션 컨트롤
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
   // 각 어절을 div로 렌더링
@@ -181,14 +186,21 @@ const CharacterBox = ({
   };
 
   const handleClick = () => {
+    // 인디케이터 활성 및 변환 플로우
     step[1] = true;
     setStep([...step]);
     temp[0] = 'data';
     setTemp([...temp]);
+
+    // 애니메이션
+    onMoveScroll();
+    setTimeout(() => {
+      startAnimation(controlScripts);
+    }, 2000);
   };
 
   return (
-    <>
+    <motion.div>
       {data ? (
         <ConvertBoxWrapper>
           <TitleText>등장인물 인식 결과</TitleText>
@@ -218,7 +230,7 @@ const CharacterBox = ({
           </ConvertButton>
         </ConvertBoxWrapper>
       )}
-    </>
+    </motion.div>
   );
 };
 

--- a/src/component/ConvertIndicator.tsx
+++ b/src/component/ConvertIndicator.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
+import {
+  ConvertStepProvider,
+  useConvertStep,
+} from '../context/convertStepContext';
 
 interface IndicatorProps {
   // 모든 단계를 거쳤는지 여부
@@ -21,12 +25,9 @@ type boxProps = {
   step: boolean;
 };
 
-const ConvertIndicator = ({
-  step,
-  select,
-  setSelect,
-  stepTabs,
-}: IndicatorProps) => {
+const ConvertIndicator = ({ select, setSelect, stepTabs }: IndicatorProps) => {
+  const { step, setStep } = useConvertStep();
+
   return (
     <IndicatorContainer>
       {stepTabs.map((item, index) => {

--- a/src/component/ConvertIndicator.tsx
+++ b/src/component/ConvertIndicator.tsx
@@ -6,29 +6,43 @@ interface IndicatorProps {
   step: boolean[]; // 현재 사용자가 위치한 단계
   select: number;
   setSelect: (select: number) => void;
+  stepTabs: Array<UseMoveScrollReturn>;
 }
 
-interface boxProps {
+type UseMoveScrollReturn = {
+  name: string;
+  onMoveElement: () => void;
+  element: React.RefObject<HTMLDivElement>;
+};
+
+type boxProps = {
   selected: number;
   index: number;
   step: boolean;
-}
+};
 
-const ConvertIndicator = ({ step, select, setSelect }: IndicatorProps) => {
-  const stepNameList: string[] = ['소설', '대본', '스토리보드', '통계'];
-
+const ConvertIndicator = ({
+  step,
+  select,
+  setSelect,
+  stepTabs,
+}: IndicatorProps) => {
   return (
     <IndicatorContainer>
-      {stepNameList.map((item, index) => {
+      {stepTabs.map((item, index) => {
         return (
           <IndicatorBox
+            disabled={step[index]}
             step={step[index]}
             key={index}
             selected={select}
             index={index}
-            onClick={() => setSelect(index)}
+            onClick={() => {
+              setSelect(index);
+              item.onMoveElement();
+            }}
           >
-            {item}
+            {item.name}
           </IndicatorBox>
         );
       })}
@@ -41,7 +55,10 @@ const IndicatorContainer = styled.div`
   gap: 5px;
 `;
 
-const IndicatorBox = styled.button<boxProps>`
+// step에 따라서 disabled 설정하기
+const IndicatorBox = styled.button.attrs((props) => ({
+  disabled: !props.disabled ? true : undefined,
+}))<boxProps>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -50,7 +67,6 @@ const IndicatorBox = styled.button<boxProps>`
   height: 30px;
   padding: 1.1rem;
   font-size: 1rem;
-  disabled: true;
 
   background-color: ${({ theme }) => theme.colors.beige};
   color: ${({ theme }) => theme.colors.brown};
@@ -61,7 +77,6 @@ const IndicatorBox = styled.button<boxProps>`
     css`
       background-color: ${theme.colors.orange};
       color: white;
-      disabled: false;
     `}
 
     ${selected === index &&

--- a/src/component/ConvertIndicator.tsx
+++ b/src/component/ConvertIndicator.tsx
@@ -63,8 +63,7 @@ const IndicatorBox = styled.button.attrs((props) => ({
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 6vw;
-  max-width: 1.5rem;
+  min-width: 7.5rem;
   height: 30px;
   padding: 1.1rem;
   font-size: 1rem;

--- a/src/component/NovelBox.tsx
+++ b/src/component/NovelBox.tsx
@@ -14,20 +14,20 @@ import {
   FileButton,
   ScrollTextArea,
 } from '../styles/convertBoxStyles';
+import { useConvertStep } from '../context/convertStepContext';
 
 type props = {
   data: string;
   onScroll: (scrollTop: number) => void;
   scrollTop: number;
-  step: boolean[];
-  setStep: (step: boolean[]) => void;
 };
 
 const NovelBox = forwardRef<HTMLDivElement, props>(
-  ({ data, onScroll, scrollTop, step, setStep }, ref) => {
+  ({ data, onScroll, scrollTop }, ref) => {
     const [text, setText] = useState<string>('');
     const fileInputRef = useRef<HTMLInputElement>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const { step, setStep } = useConvertStep(); // 변환 단계 관리
 
     // 파일 업로드
     const handleFileUpload = (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/component/NovelBox.tsx
+++ b/src/component/NovelBox.tsx
@@ -19,11 +19,12 @@ type props = {
   data: string;
   onScroll: (scrollTop: number) => void;
   scrollTop: number;
-  style?: React.CSSProperties;
+  step: boolean[];
+  setStep: (step: boolean[]) => void;
 };
 
 const NovelBox = forwardRef<HTMLDivElement, props>(
-  ({ data, onScroll, scrollTop, style }, ref) => {
+  ({ data, onScroll, scrollTop, step, setStep }, ref) => {
     const [text, setText] = useState<string>('');
     const fileInputRef = useRef<HTMLInputElement>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -52,6 +53,14 @@ const NovelBox = forwardRef<HTMLDivElement, props>(
     // textarea value
     const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
       setText(event.target.value); // textarea의 value를 업데이트합니다.
+      if (event.target.value !== '') {
+        // textarea가 비어있지 않을 때
+        step[0] = true;
+        setStep([...step]);
+      } else {
+        step[0] = false;
+        setStep([...step]);
+      }
     };
 
     // CharacterBox와 동시 스크롤
@@ -68,7 +77,7 @@ const NovelBox = forwardRef<HTMLDivElement, props>(
     };
 
     return (
-      <div ref={ref} style={style}>
+      <div ref={ref}>
         <ConvertBoxWrapper>
           <TitleText>원고 작성</TitleText>
           <FileButton onClick={handleButtonClick}>

--- a/src/component/NovelBox.tsx
+++ b/src/component/NovelBox.tsx
@@ -1,4 +1,10 @@
-import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
+import React, {
+  ChangeEvent,
+  useEffect,
+  useRef,
+  forwardRef,
+  useState,
+} from 'react';
 import styled from 'styled-components';
 import ConvertBoxWrapper from './ConvertBoxWrapper';
 import { ReactComponent as FileUploadIcon } from '../assets/icons/file_upload_icon.svg';
@@ -6,85 +12,90 @@ import {
   TitleText,
   ContentBox,
   FileButton,
-  ScrollTextArea
+  ScrollTextArea,
 } from '../styles/convertBoxStyles';
 
 type props = {
   data: string;
   onScroll: (scrollTop: number) => void;
   scrollTop: number;
+  style?: React.CSSProperties;
 };
 
+const NovelBox = forwardRef<HTMLDivElement, props>(
+  ({ data, onScroll, scrollTop, style }, ref) => {
+    const [text, setText] = useState<string>('');
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-const NovelBox = ({ data, onScroll, scrollTop }: props) => {
-  const [text, setText] = useState<string>('');
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+    // 파일 업로드
+    const handleFileUpload = (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file && file.type === 'text/plain') {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const result = e.target?.result;
+          if (result && typeof result === 'string') {
+            setText(result);
+          }
+        };
+        reader.readAsText(file);
+      } else {
+        alert('Please upload a valid text file.');
+      }
+    };
 
-  // 파일 업로드
-  const handleFileUpload = (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file && file.type === 'text/plain') {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const result = e.target?.result;
-        if (result && typeof result === 'string') {
-          setText(result);
-        }
-      };
-      reader.readAsText(file);
-    } else {
-      alert('Please upload a valid text file.');
-    }
-  };
+    const handleButtonClick = () => {
+      fileInputRef.current?.click(); // file input 요소를 클릭하여 파일 선택 대화 상자를 엽니다.
+    };
 
-  const handleButtonClick = () => {
-    fileInputRef.current?.click(); // file input 요소를 클릭하여 파일 선택 대화 상자를 엽니다.
-  };
+    // textarea value
+    const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+      setText(event.target.value); // textarea의 value를 업데이트합니다.
+    };
 
-  // textarea value
-  const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    setText(event.target.value); // textarea의 value를 업데이트합니다.
-  };
+    // CharacterBox와 동시 스크롤
+    useEffect(() => {
+      if (textareaRef.current) {
+        textareaRef.current.scrollTop = scrollTop;
+      }
+    }, [scrollTop]);
 
-  // CharacterBox와 동시 스크롤
-  useEffect(() => {
-    if (textareaRef.current) {
-      textareaRef.current.scrollTop = scrollTop;
-    }
-  }, [scrollTop]);
+    const handleScroll = () => {
+      if (textareaRef.current) {
+        onScroll(textareaRef.current.scrollTop);
+      }
+    };
 
-  const handleScroll = () => {
-    if (textareaRef.current) {
-      onScroll(textareaRef.current.scrollTop);
-    }
-  };
-  
-  return (
-    <ConvertBoxWrapper>
-      <TitleText>원고 작성</TitleText>
-      <FileButton onClick={handleButtonClick}><FileUploadIcon width="2rem" height="2rem" />&nbsp;파일 업로드</FileButton>
-      <HiddenFileInput
-        type="file"
-        accept=".txt"
-        ref={fileInputRef}
-        onChange={handleFileUpload}
-      />
-      <ContentBox>
-        <ScrollTextArea
-          value={text}
-          onChange={handleTextChange}
-          wrap="soft"
-          placeholder="내용을 입력하거나 텍스트 파일을 첨부하세요."
-          ref={textareaRef}
-          onScroll={handleScroll}
-        />
-      </ContentBox>
-    </ConvertBoxWrapper>
-
-  );
-
-};
+    return (
+      <div ref={ref} style={style}>
+        <ConvertBoxWrapper>
+          <TitleText>원고 작성</TitleText>
+          <FileButton onClick={handleButtonClick}>
+            <FileUploadIcon width="2rem" height="2rem" />
+            &nbsp;파일 업로드
+          </FileButton>
+          <HiddenFileInput
+            type="file"
+            accept=".txt"
+            ref={fileInputRef}
+            onChange={handleFileUpload}
+          />
+          <ContentBox>
+            <ScrollTextArea
+              value={text}
+              onChange={handleTextChange}
+              wrap="soft"
+              placeholder="내용을 입력하거나 텍스트 파일을 첨부하세요."
+              ref={textareaRef}
+              onScroll={handleScroll}
+            />
+          </ContentBox>
+        </ConvertBoxWrapper>
+      </div>
+    );
+  }
+);
 
 export default NovelBox;
 

--- a/src/component/ScriptBox.tsx
+++ b/src/component/ScriptBox.tsx
@@ -14,20 +14,20 @@ import {
   FileButton,
 } from '../styles/convertBoxStyles';
 import { useAnimationContext } from '../context/animationContext';
+import { useConvertStep } from '../context/convertStepContext';
 
 type props = {
   data: string;
   temp: string[];
   setTemp: (temp: string[]) => void;
-  step: boolean[];
-  setStep: (step: boolean[]) => void;
   onMoveScroll: () => void;
 };
 
 const ScriptBox = forwardRef<HTMLDivElement, props>(
-  ({ data, temp, setTemp, step, setStep, onMoveScroll }, ref) => {
+  ({ data, temp, setTemp, onMoveScroll }, ref) => {
     const { controlScripts, controlStoryboard, startAnimation } =
       useAnimationContext(); // 변환 컴포넌트 애니메이션 컨트롤
+    const { step, setStep } = useConvertStep(); // 변환 단계 관리
 
     const handleClick = () => {
       temp[1] = 'data';

--- a/src/component/ScriptBox.tsx
+++ b/src/component/ScriptBox.tsx
@@ -16,7 +16,6 @@ import {
 
 type props = {
   data: string;
-  style?: React.CSSProperties;
   temp: string[];
   setTemp: (temp: string[]) => void;
   step: boolean[];
@@ -24,7 +23,7 @@ type props = {
 };
 
 const ScriptBox = forwardRef<HTMLDivElement, props>(
-  ({ data, style, temp, setTemp, step, setStep }, ref) => {
+  ({ data, temp, setTemp, step, setStep }, ref) => {
     const handleClick = () => {
       temp[1] = 'data';
       setTemp([...temp]);
@@ -33,7 +32,7 @@ const ScriptBox = forwardRef<HTMLDivElement, props>(
     };
 
     return (
-      <div ref={ref} style={style}>
+      <div ref={ref}>
         {data ? (
           <ConvertBoxWrapper>
             <TitleText>대본화</TitleText>

--- a/src/component/ScriptBox.tsx
+++ b/src/component/ScriptBox.tsx
@@ -17,39 +17,54 @@ import {
 type props = {
   data: string;
   style?: React.CSSProperties;
+  temp: string[];
+  setTemp: (temp: string[]) => void;
+  step: boolean[];
+  setStep: (step: boolean[]) => void;
 };
 
-const ScriptBox = forwardRef<HTMLDivElement, props>(({ data, style }, ref) => {
-  return (
-    <div ref={ref} style={style}>
-      {data ? (
-        <ConvertBoxWrapper>
-          <TitleText>대본화</TitleText>
-          <FileButton>
-            <FileDownloadIcon width="2rem" height="2rem" />
-            &nbsp;다운로드
-          </FileButton>
-          <ContentBox>
-            <ScrollTextArea placeholder="텍스트" />
-          </ContentBox>
-        </ConvertBoxWrapper>
-      ) : (
-        <ConvertBoxWrapper mode="tutorial">
-          <TutorialBox>
-            <TutorialTitle>#2 소설을 대본으로 변환하기</TutorialTitle>
-            <TutorialText>
-              입력한 정보를 토대로
-              <br />
-              각 등장인물의 대사와 행위를 구분해
-              <br />
-              <HighlightedText>대본 형식으로 변환</HighlightedText>합니다.
-            </TutorialText>
-          </TutorialBox>
-          <ConvertButton>대본 변환</ConvertButton>
-        </ConvertBoxWrapper>
-      )}
-    </div>
-  );
-});
+const ScriptBox = forwardRef<HTMLDivElement, props>(
+  ({ data, style, temp, setTemp, step, setStep }, ref) => {
+    const handleClick = () => {
+      temp[1] = 'data';
+      setTemp([...temp]);
+      step[2] = true;
+      setStep([...step]);
+    };
+
+    return (
+      <div ref={ref} style={style}>
+        {data ? (
+          <ConvertBoxWrapper>
+            <TitleText>대본화</TitleText>
+            <FileButton>
+              <FileDownloadIcon width="2rem" height="2rem" />
+              &nbsp;다운로드
+            </FileButton>
+            <ContentBox>
+              <ScrollTextArea placeholder="텍스트" />
+            </ContentBox>
+          </ConvertBoxWrapper>
+        ) : (
+          <ConvertBoxWrapper mode="tutorial">
+            <TutorialBox>
+              <TutorialTitle>#2 소설을 대본으로 변환하기</TutorialTitle>
+              <TutorialText>
+                입력한 정보를 토대로
+                <br />
+                각 등장인물의 대사와 행위를 구분해
+                <br />
+                <HighlightedText>대본 형식으로 변환</HighlightedText>합니다.
+              </TutorialText>
+            </TutorialBox>
+            <ConvertButton onClick={handleClick} isWrite={true}>
+              대본 변환
+            </ConvertButton>
+          </ConvertBoxWrapper>
+        )}
+      </div>
+    );
+  }
+);
 
 export default ScriptBox;

--- a/src/component/ScriptBox.tsx
+++ b/src/component/ScriptBox.tsx
@@ -39,7 +39,7 @@ const ScriptBox = forwardRef<HTMLDivElement, props>(
       onMoveScroll();
       setTimeout(() => {
         startAnimation(controlStoryboard);
-      }, 2000);
+      }, 1000);
     };
 
     return (

--- a/src/component/ScriptBox.tsx
+++ b/src/component/ScriptBox.tsx
@@ -71,7 +71,7 @@ const ScriptBox = forwardRef<HTMLDivElement, props>(
                 <HighlightedText>대본 형식으로 변환</HighlightedText>합니다.
               </TutorialText>
             </TutorialBox>
-            <ConvertButton onClick={handleClick} isWrite={true}>
+            <ConvertButton disabled={true} onClick={handleClick} isWrite={true}>
               대본 변환
             </ConvertButton>
           </ConvertBoxWrapper>

--- a/src/component/ScriptBox.tsx
+++ b/src/component/ScriptBox.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import styled from 'styled-components';
 import ConvertBoxWrapper from './ConvertBoxWrapper';
 import { ReactComponent as FileDownloadIcon } from '../assets/icons/file_download_icon.svg';
@@ -11,43 +11,45 @@ import {
   TutorialText,
   HighlightedText,
   ConvertButton,
-  FileButton
+  FileButton,
 } from '../styles/convertBoxStyles';
-
 
 type props = {
   data: string;
+  style?: React.CSSProperties;
 };
 
-const ScriptBox = ({ data }: props) =>  {
-
+const ScriptBox = forwardRef<HTMLDivElement, props>(({ data, style }, ref) => {
   return (
-    <>
-      {data ? 
+    <div ref={ref} style={style}>
+      {data ? (
         <ConvertBoxWrapper>
           <TitleText>대본화</TitleText>
-          <FileButton><FileDownloadIcon  width="2rem" height="2rem" />&nbsp;다운로드</FileButton>
+          <FileButton>
+            <FileDownloadIcon width="2rem" height="2rem" />
+            &nbsp;다운로드
+          </FileButton>
           <ContentBox>
-            <ScrollTextArea
-              placeholder="텍스트"
-            />
+            <ScrollTextArea placeholder="텍스트" />
           </ContentBox>
         </ConvertBoxWrapper>
-      :
+      ) : (
         <ConvertBoxWrapper mode="tutorial">
           <TutorialBox>
             <TutorialTitle>#2 소설을 대본으로 변환하기</TutorialTitle>
             <TutorialText>
-              입력한 정보를 토대로<br/>
-              각 등장인물의 대사와 행위를 구분해<br/>
+              입력한 정보를 토대로
+              <br />
+              각 등장인물의 대사와 행위를 구분해
+              <br />
               <HighlightedText>대본 형식으로 변환</HighlightedText>합니다.
             </TutorialText>
           </TutorialBox>
           <ConvertButton>대본 변환</ConvertButton>
         </ConvertBoxWrapper>
-      }
-    </>
+      )}
+    </div>
   );
-};
+});
 
 export default ScriptBox;

--- a/src/component/ScriptBox.tsx
+++ b/src/component/ScriptBox.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useState } from 'react';
-import styled from 'styled-components';
+import { motion } from 'framer-motion';
 import ConvertBoxWrapper from './ConvertBoxWrapper';
 import { ReactComponent as FileDownloadIcon } from '../assets/icons/file_download_icon.svg';
 import {
@@ -13,6 +13,7 @@ import {
   ConvertButton,
   FileButton,
 } from '../styles/convertBoxStyles';
+import { useAnimationContext } from '../context/animationContext';
 
 type props = {
   data: string;
@@ -20,19 +21,29 @@ type props = {
   setTemp: (temp: string[]) => void;
   step: boolean[];
   setStep: (step: boolean[]) => void;
+  onMoveScroll: () => void;
 };
 
 const ScriptBox = forwardRef<HTMLDivElement, props>(
-  ({ data, temp, setTemp, step, setStep }, ref) => {
+  ({ data, temp, setTemp, step, setStep, onMoveScroll }, ref) => {
+    const { controlScripts, controlStoryboard, startAnimation } =
+      useAnimationContext(); // 변환 컴포넌트 애니메이션 컨트롤
+
     const handleClick = () => {
       temp[1] = 'data';
       setTemp([...temp]);
       step[2] = true;
       setStep([...step]);
+
+      // 애니메이션
+      onMoveScroll();
+      setTimeout(() => {
+        startAnimation(controlStoryboard);
+      }, 2000);
     };
 
     return (
-      <div ref={ref}>
+      <motion.div ref={ref} animate={controlScripts} style={{ opacity: 0 }}>
         {data ? (
           <ConvertBoxWrapper>
             <TitleText>대본화</TitleText>
@@ -61,7 +72,7 @@ const ScriptBox = forwardRef<HTMLDivElement, props>(
             </ConvertButton>
           </ConvertBoxWrapper>
         )}
-      </div>
+      </motion.div>
     );
   }
 );

--- a/src/component/ScriptBox.tsx
+++ b/src/component/ScriptBox.tsx
@@ -21,10 +21,11 @@ type props = {
   temp: string[];
   setTemp: (temp: string[]) => void;
   onMoveScroll: () => void;
+  setSelect: (select: number) => void;
 };
 
 const ScriptBox = forwardRef<HTMLDivElement, props>(
-  ({ data, temp, setTemp, onMoveScroll }, ref) => {
+  ({ data, temp, setTemp, onMoveScroll, setSelect }, ref) => {
     const { controlScripts, controlStoryboard, startAnimation } =
       useAnimationContext(); // 변환 컴포넌트 애니메이션 컨트롤
     const { step, setStep } = useConvertStep(); // 변환 단계 관리
@@ -34,6 +35,9 @@ const ScriptBox = forwardRef<HTMLDivElement, props>(
       setTemp([...temp]);
       step[2] = true;
       setStep([...step]);
+
+      // 인디케이터 select 값 변경
+      setSelect(2); // 스토리보드로 이동
 
       // 애니메이션
       onMoveScroll();

--- a/src/component/StatisticsBox.tsx
+++ b/src/component/StatisticsBox.tsx
@@ -1,23 +1,22 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import ConvertBoxWrapper from './ConvertBoxWrapper';
-import {
-  TitleText,
-  ContentBox,
-} from '../styles/convertBoxStyles';
+import { TitleText, ContentBox } from '../styles/convertBoxStyles';
 
 type props = {
   data: string;
+  style?: React.CSSProperties;
 };
 
-
-const StatisticsBox = ({ data }: props) => (
-  <ConvertBoxWrapper>
-    <TitleText>통계</TitleText>
-    <ContentBox>
-      
-    </ContentBox>
-  </ConvertBoxWrapper>
+const StatisticsBox = forwardRef<HTMLDivElement, props>(
+  ({ data, style }, ref) => (
+    <div ref={ref} style={style}>
+      <ConvertBoxWrapper>
+        <TitleText>통계</TitleText>
+        <ContentBox></ContentBox>
+      </ConvertBoxWrapper>
+    </div>
+  )
 );
 
 export default StatisticsBox;

--- a/src/component/StatisticsBox.tsx
+++ b/src/component/StatisticsBox.tsx
@@ -10,9 +10,9 @@ type props = {
 };
 
 const StatisticsBox = forwardRef<HTMLDivElement, props>(({ data }, ref) => {
-  const { controlStoryboard } = useAnimationContext();
+  const { controlStatistics } = useAnimationContext();
   return (
-    <motion.div ref={ref} animate={controlStoryboard} style={{ opacity: 0 }}>
+    <motion.div ref={ref} animate={controlStatistics} style={{ opacity: 0 }}>
       <ConvertBoxWrapper>
         <TitleText>통계</TitleText>
         <ContentBox></ContentBox>

--- a/src/component/StatisticsBox.tsx
+++ b/src/component/StatisticsBox.tsx
@@ -2,18 +2,23 @@ import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import ConvertBoxWrapper from './ConvertBoxWrapper';
 import { TitleText, ContentBox } from '../styles/convertBoxStyles';
+import { motion } from 'framer-motion';
+import { useAnimationContext } from '../context/animationContext';
 
 type props = {
   data: string;
 };
 
-const StatisticsBox = forwardRef<HTMLDivElement, props>(({ data }, ref) => (
-  <div ref={ref}>
-    <ConvertBoxWrapper>
-      <TitleText>통계</TitleText>
-      <ContentBox></ContentBox>
-    </ConvertBoxWrapper>
-  </div>
-));
+const StatisticsBox = forwardRef<HTMLDivElement, props>(({ data }, ref) => {
+  const { controlStoryboard } = useAnimationContext();
+  return (
+    <motion.div ref={ref} animate={controlStoryboard} style={{ opacity: 0 }}>
+      <ConvertBoxWrapper>
+        <TitleText>통계</TitleText>
+        <ContentBox></ContentBox>
+      </ConvertBoxWrapper>
+    </motion.div>
+  );
+});
 
 export default StatisticsBox;

--- a/src/component/StatisticsBox.tsx
+++ b/src/component/StatisticsBox.tsx
@@ -5,18 +5,15 @@ import { TitleText, ContentBox } from '../styles/convertBoxStyles';
 
 type props = {
   data: string;
-  style?: React.CSSProperties;
 };
 
-const StatisticsBox = forwardRef<HTMLDivElement, props>(
-  ({ data, style }, ref) => (
-    <div ref={ref} style={style}>
-      <ConvertBoxWrapper>
-        <TitleText>통계</TitleText>
-        <ContentBox></ContentBox>
-      </ConvertBoxWrapper>
-    </div>
-  )
-);
+const StatisticsBox = forwardRef<HTMLDivElement, props>(({ data }, ref) => (
+  <div ref={ref}>
+    <ConvertBoxWrapper>
+      <TitleText>통계</TitleText>
+      <ContentBox></ContentBox>
+    </ConvertBoxWrapper>
+  </div>
+));
 
 export default StatisticsBox;

--- a/src/component/StoryboardBox.tsx
+++ b/src/component/StoryboardBox.tsx
@@ -24,10 +24,11 @@ type props = {
   temp: string[];
   setTemp: (temp: string[]) => void;
   onMoveScroll: () => void;
+  setSelect: (select: number) => void;
 };
 
 const StoryboardBox = forwardRef<HTMLDivElement, props>(
-  ({ data, temp, setTemp, onMoveScroll }, ref) => {
+  ({ data, temp, setTemp, onMoveScroll, setSelect }, ref) => {
     const { controlStatistics, controlStoryboard, startAnimation } =
       useAnimationContext(); // 변환 컴포넌트 애니메이션 컨트롤
     const { step, setStep } = useConvertStep(); // 변환 단계 관리
@@ -67,6 +68,9 @@ const StoryboardBox = forwardRef<HTMLDivElement, props>(
       setStep([...step]);
       temp[2] = 'data';
       setTemp([...temp]);
+
+      // 인디케이터 select 값 변경
+      setSelect(3); // 통계로 이동
 
       // 애니메이션
       onMoveScroll();

--- a/src/component/StoryboardBox.tsx
+++ b/src/component/StoryboardBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import ConvertBoxWrapper from './ConvertBoxWrapper';
 import { ReactComponent as FileDownloadIcon } from '../assets/icons/file_download_icon.svg';
@@ -11,69 +11,82 @@ import {
   HighlightedText,
   ConvertButton,
   FileButton,
-  ScrollText
+  ScrollText,
 } from '../styles/convertBoxStyles';
 import StoryboardInfo from './StoryboardInfo';
 import CutList from './CutList';
 
 type props = {
-  data: string;  // 추후 스토리보드 객체로 교체
+  data: string; // 추후 스토리보드 객체로 교체
+  style?: React.CSSProperties;
 };
 
-const StoryboardBox = ({ data }: props) => {
-  // dummy data (스토리보드 객체)
-  const cuts = [
-    { cutNum: 1, 
-      angleCam: 'wide shot',
-      cutText: '모니터 화면에 붉은 여우 한 마리가 이리저리 움직이고 있다.',
-      cutImage: "link"
-    },
-    { cutNum: 2,
-      angleCam: 'bust shot',
-      cutText: '화면이 움직이자 여우 사육사가 나타난다. 여우사육사: 제가 보기엔 괜찮은데, 어떠세요?',
-      cutImage: "link"
-    },
-    { cutNum: 3,
-      angleCam: 'close up',
-      cutText: '소원: 그러네요. 근데, 여기선 뒷발이 좀 부자연스러웠거든요.',
-      cutImage: "link"
-    },
-  ];
-  const storyboardInfo = {
-    sceneNum: 1,
-    locate: "청주 동물원 - 소원의 집",
-    time: "해가 지기 직전",
-    summary: "다른 동물원에 보낸 동물들을 걱정하는 소원.",
-    cutCount: cuts.length
-  };
+const StoryboardBox = forwardRef<HTMLDivElement, props>(
+  ({ data, style }, ref) => {
+    // dummy data (스토리보드 객체)
+    const cuts = [
+      {
+        cutNum: 1,
+        angleCam: 'wide shot',
+        cutText: '모니터 화면에 붉은 여우 한 마리가 이리저리 움직이고 있다.',
+        cutImage: 'link',
+      },
+      {
+        cutNum: 2,
+        angleCam: 'bust shot',
+        cutText:
+          '화면이 움직이자 여우 사육사가 나타난다. 여우사육사: 제가 보기엔 괜찮은데, 어떠세요?',
+        cutImage: 'link',
+      },
+      {
+        cutNum: 3,
+        angleCam: 'close up',
+        cutText: '소원: 그러네요. 근데, 여기선 뒷발이 좀 부자연스러웠거든요.',
+        cutImage: 'link',
+      },
+    ];
+    const storyboardInfo = {
+      sceneNum: 1,
+      locate: '청주 동물원 - 소원의 집',
+      time: '해가 지기 직전',
+      summary: '다른 동물원에 보낸 동물들을 걱정하는 소원.',
+      cutCount: cuts.length,
+    };
 
-  return (
-    <>
-      {data ? 
-        <ConvertBoxWrapper>
-          <TitleText>스토리보드</TitleText>
-          <FileButton><FileDownloadIcon  width="2rem" height="2rem" />&nbsp;다운로드</FileButton>
-          <ContentBox>
-            <ScrollText>
-              <StoryboardInfo data={storyboardInfo} />
-              <CutList cuts={cuts} />
-            </ScrollText>
-          </ContentBox>
-        </ConvertBoxWrapper>
-      :
-        <ConvertBoxWrapper mode="tutorial">
-          <TutorialBox>
-            <TutorialTitle>#3 스토리보드 생성과 챗봇 기능</TutorialTitle>
-            <TutorialText>
-              1. 대본에 기반한 <HighlightedText>스토리보드</HighlightedText>가 생성됩니다.<br/>
-              2. 수정과 각색에 도움을 주는 <HighlightedText>챗봇</HighlightedText>을 사용할 수 있습니다.
-            </TutorialText>
-          </TutorialBox>
-          <ConvertButton>스토리보드 변환</ConvertButton>
-        </ConvertBoxWrapper>
-      }
-    </>
-  );
-};
+    return (
+      <div ref={ref} style={style}>
+        {data ? (
+          <ConvertBoxWrapper>
+            <TitleText>스토리보드</TitleText>
+            <FileButton>
+              <FileDownloadIcon width="2rem" height="2rem" />
+              &nbsp;다운로드
+            </FileButton>
+            <ContentBox>
+              <ScrollText>
+                <StoryboardInfo data={storyboardInfo} />
+                <CutList cuts={cuts} />
+              </ScrollText>
+            </ContentBox>
+          </ConvertBoxWrapper>
+        ) : (
+          <ConvertBoxWrapper mode="tutorial">
+            <TutorialBox>
+              <TutorialTitle>#3 스토리보드 생성과 챗봇 기능</TutorialTitle>
+              <TutorialText>
+                1. 대본에 기반한 <HighlightedText>스토리보드</HighlightedText>가
+                생성됩니다.
+                <br />
+                2. 수정과 각색에 도움을 주는{' '}
+                <HighlightedText>챗봇</HighlightedText>을 사용할 수 있습니다.
+              </TutorialText>
+            </TutorialBox>
+            <ConvertButton>스토리보드 변환</ConvertButton>
+          </ConvertBoxWrapper>
+        )}
+      </div>
+    );
+  }
+);
 
 export default StoryboardBox;

--- a/src/component/StoryboardBox.tsx
+++ b/src/component/StoryboardBox.tsx
@@ -21,14 +21,13 @@ import { useConvertStep } from '../context/convertStepContext';
 
 type props = {
   data: string; // 추후 스토리보드 객체로 교체
-  isWrite: boolean;
   temp: string[];
   setTemp: (temp: string[]) => void;
   onMoveScroll: () => void;
 };
 
 const StoryboardBox = forwardRef<HTMLDivElement, props>(
-  ({ data, isWrite, temp, setTemp, onMoveScroll }, ref) => {
+  ({ data, temp, setTemp, onMoveScroll }, ref) => {
     const { controlStatistics, controlStoryboard, startAnimation } =
       useAnimationContext(); // 변환 컴포넌트 애니메이션 컨트롤
     const { step, setStep } = useConvertStep(); // 변환 단계 관리
@@ -73,7 +72,7 @@ const StoryboardBox = forwardRef<HTMLDivElement, props>(
       onMoveScroll();
       setTimeout(() => {
         startAnimation(controlStatistics);
-      }, 2000);
+      }, 1000);
     };
 
     return (

--- a/src/component/StoryboardBox.tsx
+++ b/src/component/StoryboardBox.tsx
@@ -108,7 +108,11 @@ const StoryboardBox = forwardRef<HTMLDivElement, props>(
               </TutorialText>
             </TutorialBox>
             {/* 대본 변환 후 버튼 활성화 */}
-            <ConvertButton onClick={handleClick} isWrite={step[1]}>
+            <ConvertButton
+              disabled={step[1]}
+              onClick={handleClick}
+              isWrite={step[1]}
+            >
               스토리보드 변환
             </ConvertButton>
           </ConvertBoxWrapper>

--- a/src/component/StoryboardBox.tsx
+++ b/src/component/StoryboardBox.tsx
@@ -17,21 +17,21 @@ import StoryboardInfo from './StoryboardInfo';
 import CutList from './CutList';
 import { motion } from 'framer-motion';
 import { useAnimationContext } from '../context/animationContext';
+import { useConvertStep } from '../context/convertStepContext';
 
 type props = {
   data: string; // 추후 스토리보드 객체로 교체
   isWrite: boolean;
   temp: string[];
   setTemp: (temp: string[]) => void;
-  step: boolean[];
-  setStep: (step: boolean[]) => void;
   onMoveScroll: () => void;
 };
 
 const StoryboardBox = forwardRef<HTMLDivElement, props>(
-  ({ data, isWrite, step, setStep, temp, setTemp, onMoveScroll }, ref) => {
+  ({ data, isWrite, temp, setTemp, onMoveScroll }, ref) => {
     const { controlStatistics, controlStoryboard, startAnimation } =
       useAnimationContext(); // 변환 컴포넌트 애니메이션 컨트롤
+    const { step, setStep } = useConvertStep(); // 변환 단계 관리
 
     // dummy data (스토리보드 객체)
     const cuts = [
@@ -104,7 +104,8 @@ const StoryboardBox = forwardRef<HTMLDivElement, props>(
                 <HighlightedText>챗봇</HighlightedText>을 사용할 수 있습니다.
               </TutorialText>
             </TutorialBox>
-            <ConvertButton onClick={handleClick} isWrite={isWrite}>
+            {/* 대본 변환 후 버튼 활성화 */}
+            <ConvertButton onClick={handleClick} isWrite={step[1]}>
               스토리보드 변환
             </ConvertButton>
           </ConvertBoxWrapper>

--- a/src/component/StoryboardBox.tsx
+++ b/src/component/StoryboardBox.tsx
@@ -15,6 +15,8 @@ import {
 } from '../styles/convertBoxStyles';
 import StoryboardInfo from './StoryboardInfo';
 import CutList from './CutList';
+import { motion } from 'framer-motion';
+import { useAnimationContext } from '../context/animationContext';
 
 type props = {
   data: string; // 추후 스토리보드 객체로 교체
@@ -23,10 +25,14 @@ type props = {
   setTemp: (temp: string[]) => void;
   step: boolean[];
   setStep: (step: boolean[]) => void;
+  onMoveScroll: () => void;
 };
 
 const StoryboardBox = forwardRef<HTMLDivElement, props>(
-  ({ data, isWrite, step, setStep, temp, setTemp }, ref) => {
+  ({ data, isWrite, step, setStep, temp, setTemp, onMoveScroll }, ref) => {
+    const { controlStatistics, controlStoryboard, startAnimation } =
+      useAnimationContext(); // 변환 컴포넌트 애니메이션 컨트롤
+
     // dummy data (스토리보드 객체)
     const cuts = [
       {
@@ -62,10 +68,16 @@ const StoryboardBox = forwardRef<HTMLDivElement, props>(
       setStep([...step]);
       temp[2] = 'data';
       setTemp([...temp]);
+
+      // 애니메이션
+      onMoveScroll();
+      setTimeout(() => {
+        startAnimation(controlStatistics);
+      }, 2000);
     };
 
     return (
-      <div ref={ref}>
+      <motion.div ref={ref} animate={controlStoryboard} style={{ opacity: 0 }}>
         {data ? (
           <ConvertBoxWrapper>
             <TitleText>스토리보드</TitleText>
@@ -97,7 +109,7 @@ const StoryboardBox = forwardRef<HTMLDivElement, props>(
             </ConvertButton>
           </ConvertBoxWrapper>
         )}
-      </div>
+      </motion.div>
     );
   }
 );

--- a/src/component/StoryboardBox.tsx
+++ b/src/component/StoryboardBox.tsx
@@ -18,7 +18,6 @@ import CutList from './CutList';
 
 type props = {
   data: string; // 추후 스토리보드 객체로 교체
-  style?: React.CSSProperties;
   isWrite: boolean;
   temp: string[];
   setTemp: (temp: string[]) => void;
@@ -27,7 +26,7 @@ type props = {
 };
 
 const StoryboardBox = forwardRef<HTMLDivElement, props>(
-  ({ data, style, isWrite, step, setStep, temp, setTemp }, ref) => {
+  ({ data, isWrite, step, setStep, temp, setTemp }, ref) => {
     // dummy data (스토리보드 객체)
     const cuts = [
       {
@@ -66,7 +65,7 @@ const StoryboardBox = forwardRef<HTMLDivElement, props>(
     };
 
     return (
-      <div ref={ref} style={style}>
+      <div ref={ref}>
         {data ? (
           <ConvertBoxWrapper>
             <TitleText>스토리보드</TitleText>

--- a/src/component/StoryboardBox.tsx
+++ b/src/component/StoryboardBox.tsx
@@ -19,10 +19,15 @@ import CutList from './CutList';
 type props = {
   data: string; // 추후 스토리보드 객체로 교체
   style?: React.CSSProperties;
+  isWrite: boolean;
+  temp: string[];
+  setTemp: (temp: string[]) => void;
+  step: boolean[];
+  setStep: (step: boolean[]) => void;
 };
 
 const StoryboardBox = forwardRef<HTMLDivElement, props>(
-  ({ data, style }, ref) => {
+  ({ data, style, isWrite, step, setStep, temp, setTemp }, ref) => {
     // dummy data (스토리보드 객체)
     const cuts = [
       {
@@ -53,6 +58,13 @@ const StoryboardBox = forwardRef<HTMLDivElement, props>(
       cutCount: cuts.length,
     };
 
+    const handleClick = () => {
+      step[3] = true;
+      setStep([...step]);
+      temp[2] = 'data';
+      setTemp([...temp]);
+    };
+
     return (
       <div ref={ref} style={style}>
         {data ? (
@@ -81,7 +93,9 @@ const StoryboardBox = forwardRef<HTMLDivElement, props>(
                 <HighlightedText>챗봇</HighlightedText>을 사용할 수 있습니다.
               </TutorialText>
             </TutorialBox>
-            <ConvertButton>스토리보드 변환</ConvertButton>
+            <ConvertButton onClick={handleClick} isWrite={isWrite}>
+              스토리보드 변환
+            </ConvertButton>
           </ConvertBoxWrapper>
         )}
       </div>

--- a/src/context/animationContext.tsx
+++ b/src/context/animationContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext } from 'react';
+import { AnimationControls } from 'framer-motion';
+import { useConvertAnimation } from '../hooks/useConvertAnimation';
+
+type animationContextType = {
+  controlScripts: AnimationControls;
+  controlStoryboard: AnimationControls;
+  controlStatistics: AnimationControls;
+  startAnimation: (controls: AnimationControls) => void;
+};
+
+// 전역: 컨택스트 정의
+const AnimationContext = createContext<animationContextType | undefined>(
+  undefined
+);
+
+// 컨택스트를 전역적으로 제공할 수 있는 프로바이더 작성
+const AnimationProvider = ({ children }: { children: React.ReactNode }) => {
+  const animation = useConvertAnimation();
+
+  // 자식 객체에게 provider을 통해 control 객체 제공
+  return (
+    <AnimationContext.Provider value={animation}>
+      {children}
+    </AnimationContext.Provider>
+  );
+};
+
+// AnimationContext에서 값을 가져와 전역적 사용.
+// 컨텍스트가 올바르게 설정되었는지 확인.
+const useAnimationContext = (): animationContextType => {
+  const context = useContext(AnimationContext);
+  if (!context) {
+    // 컨텍스트가 설정되지 않은 경우
+    throw new Error(
+      'useAnimationContext must be used within an AnimationProvider'
+    );
+  }
+  return context;
+};
+
+export { AnimationProvider, useAnimationContext };

--- a/src/context/convertStepContext.tsx
+++ b/src/context/convertStepContext.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useState } from 'react';
+
+type stepContextType = {
+  step: boolean[];
+  setStep: React.Dispatch<React.SetStateAction<boolean[]>>;
+};
+
+// 전역: 컨택스트 정의
+const StepContext = createContext<stepContextType | undefined>({
+  step: [false, false, false, false],
+  setStep: () => {},
+});
+
+// 컨택스트를 전역적으로 제공할 수 있는 프로바이더 작성
+const ConvertStepProvider = ({ children }: { children: React.ReactNode }) => {
+  const [step, setStep] = useState<boolean[]>([false, false, false, false]);
+
+  // 자식 객체에게 provider을 통해 control 객체 제공
+  return (
+    <StepContext.Provider value={{ step, setStep }}>
+      {children}
+    </StepContext.Provider>
+  );
+};
+
+// 컨텍스트 값을 사용하는 커스텀 훅
+const useConvertStep = () => {
+  const context = useContext(StepContext);
+  if (context === undefined) {
+    throw new Error('useStep must be used within a StepProvider');
+  }
+  return context;
+};
+
+export { ConvertStepProvider, useConvertStep };

--- a/src/hooks/useConvertAnimation.tsx
+++ b/src/hooks/useConvertAnimation.tsx
@@ -1,0 +1,25 @@
+import { useAnimation, AnimationControls } from 'framer-motion';
+
+export const useConvertAnimation = () => {
+  const controlScripts = useAnimation();
+  const controlStoryboard = useAnimation();
+  const controlStatistics = useAnimation();
+
+  const startAnimation = (controls: AnimationControls) => {
+    controls.start({
+      opacity: [0, 0.2, 0.5, 0.8, 1],
+      scale: [0.8, 1],
+      transition: {
+        duration: 1,
+        ease: 'easeInOut',
+        times: [0, 0.2, 0.5, 0.8, 1],
+      },
+    });
+  };
+  return {
+    controlScripts,
+    controlStoryboard,
+    controlStatistics,
+    startAnimation,
+  };
+};

--- a/src/hooks/useMoveScroll.tsx
+++ b/src/hooks/useMoveScroll.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 
 // ref 위치로 scroll하는 use hook
-const useMoveScroll = (name: string) => {
+export const useMoveScroll = (name: string) => {
   const element = useRef<HTMLDivElement>(null);
   const onMoveElement = () => {
     console.log(element);
@@ -10,5 +10,3 @@ const useMoveScroll = (name: string) => {
 
   return { element, name, onMoveElement };
 };
-
-export default useMoveScroll;

--- a/src/hooks/useMoveScroll.tsx
+++ b/src/hooks/useMoveScroll.tsx
@@ -1,0 +1,14 @@
+import { useRef } from 'react';
+
+// ref 위치로 scroll하는 use hook
+const useMoveScroll = (name: string) => {
+  const element = useRef<HTMLDivElement>(null);
+  const onMoveElement = () => {
+    console.log(element);
+    element.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return { element, name, onMoveElement };
+};
+
+export default useMoveScroll;

--- a/src/hooks/useMoveScroll.tsx
+++ b/src/hooks/useMoveScroll.tsx
@@ -5,7 +5,7 @@ const useMoveScroll = (name: string) => {
   const element = useRef<HTMLDivElement>(null);
   const onMoveElement = () => {
     console.log(element);
-    element.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    element.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
   };
 
   return { element, name, onMoveElement };

--- a/src/page/ConvertPage.tsx
+++ b/src/page/ConvertPage.tsx
@@ -77,6 +77,7 @@ const ConvertPage = () => {
                 scrollTop={scrollTop}
                 temp={temp}
                 setTemp={setTemp}
+                setSelect={setSelect}
                 onMoveScroll={stepTabs[1].onMoveElement}
               />
               <ScriptBox
@@ -84,6 +85,7 @@ const ConvertPage = () => {
                 data={temp[1]}
                 temp={temp}
                 setTemp={setTemp}
+                setSelect={setSelect}
                 onMoveScroll={stepTabs[2].onMoveElement}
               />
               <StoryboardBox
@@ -91,6 +93,7 @@ const ConvertPage = () => {
                 data={temp[2]}
                 temp={temp}
                 setTemp={setTemp}
+                setSelect={setSelect}
                 onMoveScroll={stepTabs[3].onMoveElement}
               />
               <StatisticsBox ref={stepTabs[3].element} data="" />

--- a/src/page/ConvertPage.tsx
+++ b/src/page/ConvertPage.tsx
@@ -75,7 +75,6 @@ const ConvertPage = () => {
                 data={temp[0]}
                 onScroll={handleScroll}
                 scrollTop={scrollTop}
-                isWrite={step[0]}
                 temp={temp}
                 setTemp={setTemp}
                 onMoveScroll={stepTabs[1].onMoveElement}
@@ -90,7 +89,6 @@ const ConvertPage = () => {
               <StoryboardBox
                 ref={stepTabs[2].element}
                 data={temp[2]}
-                isWrite={step[1]}
                 temp={temp}
                 setTemp={setTemp}
                 onMoveScroll={stepTabs[3].onMoveElement}

--- a/src/page/ConvertPage.tsx
+++ b/src/page/ConvertPage.tsx
@@ -16,9 +16,13 @@ interface TextProps {
   weight: string;
 }
 const ConvertPage = () => {
-  const [step, setStep] = useState([true, true, false, false]); // 진행도
+  const [step, setStep] = useState([false, false, false, false]); // 진행도
   const [select, setSelect] = useState(0); // 사용자가 선택한 컴포넌트
   const [scrollTop, setScrollTop] = useState(0); // NevelBox, CharacterBox 동시 스크롤
+
+  // 화면 애니메이션을 위한 임시 상태 관리, 추후에 api 호출로 수정
+  // 상호참조, 대본, 스토리보드(버튼 클릭 전/후)
+  const [temp, setTemp] = useState(['', '', '']);
 
   const handleScroll = (newScrollTop: number) => {
     setScrollTop(newScrollTop);
@@ -58,31 +62,52 @@ const ConvertPage = () => {
         <ConvertStepWrapper>
           <NovelBox
             ref={stepTabs[0].element}
-            data="novel"
+            data=""
             onScroll={handleScroll}
             scrollTop={scrollTop}
-            style={{ opacity: step[0] ? 1 : 0 }}
+            step={step}
+            setStep={setStep}
           />
           <CharacterBox
-            data="character"
+            data={temp[0]}
             onScroll={handleScroll}
             scrollTop={scrollTop}
+            isWrite={step[0]}
+            temp={temp}
+            setTemp={setTemp}
+            step={step}
+            setStep={setStep}
           />
-          <ScriptBox
-            ref={stepTabs[1].element}
-            data="script"
-            style={{ opacity: step[1] ? 1 : 0 }}
-          />
-          <StoryboardBox
-            ref={stepTabs[2].element}
-            data="story"
-            style={{ opacity: step[2] ? 1 : 0 }}
-          />
-          <StatisticsBox
-            ref={stepTabs[3].element}
-            data=""
-            style={{ opacity: step[3] ? 1 : 0 }}
-          />
+          {step[1] && (
+            <ScriptBox
+              ref={stepTabs[1].element}
+              data={temp[1]}
+              style={{ opacity: step[1] ? 1 : 0 }}
+              temp={temp}
+              setTemp={setTemp}
+              step={step}
+              setStep={setStep}
+            />
+          )}
+          {step[2] && (
+            <StoryboardBox
+              ref={stepTabs[2].element}
+              data={temp[2]}
+              style={{ opacity: step[2] ? 1 : 0 }}
+              isWrite={step[1]}
+              temp={temp}
+              setTemp={setTemp}
+              step={step}
+              setStep={setStep}
+            />
+          )}
+          {step[3] && (
+            <StatisticsBox
+              ref={stepTabs[3].element}
+              data=""
+              style={{ opacity: step[3] ? 1 : 0 }}
+            />
+          )}
         </ConvertStepWrapper>
       </BackgroundCover>
     </Background>

--- a/src/page/ConvertPage.tsx
+++ b/src/page/ConvertPage.tsx
@@ -8,8 +8,8 @@ import StoryboardBox from '../component/StoryboardBox';
 import StatisticsBox from '../component/StatisticsBox';
 import bgImg from '../assets/background/bg-5.png';
 import { ReactComponent as SaveFileIcon } from '../assets/icons/save_file_icon.svg';
-import useMoveScroll from '../hooks/useMoveScroll';
-import { motion, useAnimation } from 'framer-motion';
+import { useMoveScroll } from '../hooks/useMoveScroll';
+import { AnimationProvider } from '../context/animationContext';
 
 interface TextProps {
   color: string;
@@ -24,8 +24,6 @@ const ConvertPage = () => {
   // 화면 애니메이션을 위한 임시 상태 관리, 추후에 api 호출로 수정
   // 상호참조, 대본, 스토리보드(버튼 클릭 전/후)
   const [temp, setTemp] = useState(['', '', '']);
-
-  const controls = useAnimation(); // 변환 컴포넌트 애니메이션 컨트롤
 
   const handleScroll = (newScrollTop: number) => {
     setScrollTop(newScrollTop);
@@ -62,26 +60,28 @@ const ConvertPage = () => {
             </SaveButtonBox>
           </IndicatorBox>
         </TopContainer>
-        <ConvertStepWrapper>
-          <NovelBox
-            ref={stepTabs[0].element}
-            data=""
-            onScroll={handleScroll}
-            scrollTop={scrollTop}
-            step={step}
-            setStep={setStep}
-          />
-          <CharacterBox
-            data={temp[0]}
-            onScroll={handleScroll}
-            scrollTop={scrollTop}
-            isWrite={step[0]}
-            temp={temp}
-            setTemp={setTemp}
-            step={step}
-            setStep={setStep}
-          />
-          {step[1] && (
+        {/* components */}
+        <AnimationProvider>
+          <ConvertStepWrapper>
+            <NovelBox
+              ref={stepTabs[0].element}
+              data=""
+              onScroll={handleScroll}
+              scrollTop={scrollTop}
+              step={step}
+              setStep={setStep}
+            />
+            <CharacterBox
+              data={temp[0]}
+              onScroll={handleScroll}
+              scrollTop={scrollTop}
+              isWrite={step[0]}
+              temp={temp}
+              setTemp={setTemp}
+              step={step}
+              setStep={setStep}
+              onMoveScroll={stepTabs[1].onMoveElement}
+            />
             <ScriptBox
               ref={stepTabs[1].element}
               data={temp[1]}
@@ -89,9 +89,8 @@ const ConvertPage = () => {
               setTemp={setTemp}
               step={step}
               setStep={setStep}
+              onMoveScroll={stepTabs[2].onMoveElement}
             />
-          )}
-          {step[2] && (
             <StoryboardBox
               ref={stepTabs[2].element}
               data={temp[2]}
@@ -100,10 +99,11 @@ const ConvertPage = () => {
               setTemp={setTemp}
               step={step}
               setStep={setStep}
+              onMoveScroll={stepTabs[3].onMoveElement}
             />
-          )}
-          {step[3] && <StatisticsBox ref={stepTabs[3].element} data="" />}
-        </ConvertStepWrapper>
+            <StatisticsBox ref={stepTabs[3].element} data="" />
+          </ConvertStepWrapper>
+        </AnimationProvider>
       </BackgroundCover>
     </Background>
   );

--- a/src/page/ConvertPage.tsx
+++ b/src/page/ConvertPage.tsx
@@ -9,6 +9,7 @@ import StatisticsBox from '../component/StatisticsBox';
 import bgImg from '../assets/background/bg-5.png';
 import { ReactComponent as SaveFileIcon } from '../assets/icons/save_file_icon.svg';
 import useMoveScroll from '../hooks/useMoveScroll';
+import { motion, useAnimation } from 'framer-motion';
 
 interface TextProps {
   color: string;
@@ -23,6 +24,8 @@ const ConvertPage = () => {
   // 화면 애니메이션을 위한 임시 상태 관리, 추후에 api 호출로 수정
   // 상호참조, 대본, 스토리보드(버튼 클릭 전/후)
   const [temp, setTemp] = useState(['', '', '']);
+
+  const controls = useAnimation(); // 변환 컴포넌트 애니메이션 컨트롤
 
   const handleScroll = (newScrollTop: number) => {
     setScrollTop(newScrollTop);
@@ -82,7 +85,6 @@ const ConvertPage = () => {
             <ScriptBox
               ref={stepTabs[1].element}
               data={temp[1]}
-              style={{ opacity: step[1] ? 1 : 0 }}
               temp={temp}
               setTemp={setTemp}
               step={step}
@@ -93,7 +95,6 @@ const ConvertPage = () => {
             <StoryboardBox
               ref={stepTabs[2].element}
               data={temp[2]}
-              style={{ opacity: step[2] ? 1 : 0 }}
               isWrite={step[1]}
               temp={temp}
               setTemp={setTemp}
@@ -101,13 +102,7 @@ const ConvertPage = () => {
               setStep={setStep}
             />
           )}
-          {step[3] && (
-            <StatisticsBox
-              ref={stepTabs[3].element}
-              data=""
-              style={{ opacity: step[3] ? 1 : 0 }}
-            />
-          )}
+          {step[3] && <StatisticsBox ref={stepTabs[3].element} data="" />}
         </ConvertStepWrapper>
       </BackgroundCover>
     </Background>
@@ -139,6 +134,11 @@ const ConvertStepWrapper = styled.div`
   overflow-x: scroll;
   gap: 0 10vw;
   padding: 10vh 0; // TopContainer > height와 값 동일, margin을 주기 위해 값 크게해도 됨
+
+  // 스크롤바 숨김
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const TopContainer = styled.div`

--- a/src/page/ConvertPage.tsx
+++ b/src/page/ConvertPage.tsx
@@ -8,6 +8,7 @@ import StoryboardBox from '../component/StoryboardBox';
 import StatisticsBox from '../component/StatisticsBox';
 import bgImg from '../assets/background/bg-5.png';
 import { ReactComponent as SaveFileIcon } from '../assets/icons/save_file_icon.svg';
+import useMoveScroll from '../hooks/useMoveScroll';
 
 interface TextProps {
   color: string;
@@ -15,13 +16,21 @@ interface TextProps {
   weight: string;
 }
 const ConvertPage = () => {
-  const [step, setStep] = useState([false, false, false, false]); // 진행도
+  const [step, setStep] = useState([true, true, false, false]); // 진행도
   const [select, setSelect] = useState(0); // 사용자가 선택한 컴포넌트
   const [scrollTop, setScrollTop] = useState(0); // NevelBox, CharacterBox 동시 스크롤
 
   const handleScroll = (newScrollTop: number) => {
     setScrollTop(newScrollTop);
   };
+
+  // 인디케이터 이동
+  const stepTabs = [
+    useMoveScroll('소설'),
+    useMoveScroll('대본'),
+    useMoveScroll('스토리보드'),
+    useMoveScroll('통계'),
+  ];
 
   return (
     <Background>
@@ -35,6 +44,7 @@ const ConvertPage = () => {
               step={step}
               select={select}
               setSelect={setSelect}
+              stepTabs={stepTabs}
             />
             <div style={{ width: '2rem' }} />
             <SaveButtonBox>
@@ -47,18 +57,32 @@ const ConvertPage = () => {
         </TopContainer>
         <ConvertStepWrapper>
           <NovelBox
+            ref={stepTabs[0].element}
             data="novel"
             onScroll={handleScroll}
             scrollTop={scrollTop}
+            style={{ opacity: step[0] ? 1 : 0 }}
           />
           <CharacterBox
             data="character"
             onScroll={handleScroll}
             scrollTop={scrollTop}
           />
-          <ScriptBox data="script" />
-          <StoryboardBox data="story" />
-          <StatisticsBox data="" />
+          <ScriptBox
+            ref={stepTabs[1].element}
+            data="script"
+            style={{ opacity: step[1] ? 1 : 0 }}
+          />
+          <StoryboardBox
+            ref={stepTabs[2].element}
+            data="story"
+            style={{ opacity: step[2] ? 1 : 0 }}
+          />
+          <StatisticsBox
+            ref={stepTabs[3].element}
+            data=""
+            style={{ opacity: step[3] ? 1 : 0 }}
+          />
         </ConvertStepWrapper>
       </BackgroundCover>
     </Background>

--- a/src/page/ConvertPage.tsx
+++ b/src/page/ConvertPage.tsx
@@ -137,6 +137,10 @@ const ConvertStepWrapper = styled.div`
   &::-webkit-scrollbar {
     display: none;
   }
+
+  @media ${({ theme }) => theme.mediaSize.xl} {
+    padding: 15vh 0; // TopContainer > height와 값 동일, margin을 주기 위해 값 크게해도 됨
+  }
 `;
 
 const TopContainer = styled.div`
@@ -144,12 +148,18 @@ const TopContainer = styled.div`
   display: flex;
   align-items: center;
   height: 10vh;
-  gap: 10vw;
+  gap: 0 10vw;
+
+  @media ${({ theme }) => theme.mediaSize.xl} {
+    flex-direction: column;
+    gap: 1rem 0;
+    padding: 1rem 0;
+  }
 `;
 
 const IndicatorBox = styled.div`
+  min-width: 41rem;
   display: flex;
-  max-width: 650px;
   align-items: center;
   gap: 0.7rem;
 `;
@@ -162,8 +172,7 @@ const SaveButtonBox = styled.div`
 const TitleInputBox = styled.div`
   display: flex;
   align-items: center;
-  width: 50vw; // equal convert box width
-  max-width: 650px;
+  min-width: 41rem;
   height: 3rem;
   padding: 1rem;
   border-style: solid;

--- a/src/page/ConvertPage.tsx
+++ b/src/page/ConvertPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import ConvertIndicator from '../component/ConvertIndicator';
 import NovelBox from '../component/NovelBox';
 import CharacterBox from '../component/CharacterBox';
@@ -116,7 +116,9 @@ const Background = styled.div`
   justify-content: center;
   background-image: url(${bgImg});
   background-size: cover;
-  height: 100vh;
+  ${css`
+    height: calc(100vh - 80px);
+  `}
 `;
 
 const BackgroundCover = styled.p`
@@ -126,6 +128,10 @@ const BackgroundCover = styled.p`
   background-color: rgba(166, 162, 154, 0.4);
   backdrop-filter: blur(3px);
   padding: 0 5vw;
+
+  ${css`
+    height: calc(100vh - 80px);
+  `}
 `;
 
 // container

--- a/src/page/ConvertPage.tsx
+++ b/src/page/ConvertPage.tsx
@@ -10,6 +10,7 @@ import bgImg from '../assets/background/bg-5.png';
 import { ReactComponent as SaveFileIcon } from '../assets/icons/save_file_icon.svg';
 import { useMoveScroll } from '../hooks/useMoveScroll';
 import { AnimationProvider } from '../context/animationContext';
+import { ConvertStepProvider } from '../context/convertStepContext';
 
 interface TextProps {
   color: string;
@@ -40,70 +41,64 @@ const ConvertPage = () => {
   return (
     <Background>
       <BackgroundCover>
-        <TopContainer>
-          <TitleInputBox>
-            <TitleInput placeholder="제목을 입력해주세요.(n0자)" />
-          </TitleInputBox>
-          <IndicatorBox>
-            <ConvertIndicator
-              step={step}
-              select={select}
-              setSelect={setSelect}
-              stepTabs={stepTabs}
-            />
-            <div style={{ width: '2rem' }} />
-            <SaveButtonBox>
-              <SaveButton>
-                <SaveFileIcon width={25} />
-                저장
-              </SaveButton>
-            </SaveButtonBox>
-          </IndicatorBox>
-        </TopContainer>
-        {/* components */}
-        <AnimationProvider>
-          <ConvertStepWrapper>
-            <NovelBox
-              ref={stepTabs[0].element}
-              data=""
-              onScroll={handleScroll}
-              scrollTop={scrollTop}
-              step={step}
-              setStep={setStep}
-            />
-            <CharacterBox
-              data={temp[0]}
-              onScroll={handleScroll}
-              scrollTop={scrollTop}
-              isWrite={step[0]}
-              temp={temp}
-              setTemp={setTemp}
-              step={step}
-              setStep={setStep}
-              onMoveScroll={stepTabs[1].onMoveElement}
-            />
-            <ScriptBox
-              ref={stepTabs[1].element}
-              data={temp[1]}
-              temp={temp}
-              setTemp={setTemp}
-              step={step}
-              setStep={setStep}
-              onMoveScroll={stepTabs[2].onMoveElement}
-            />
-            <StoryboardBox
-              ref={stepTabs[2].element}
-              data={temp[2]}
-              isWrite={step[1]}
-              temp={temp}
-              setTemp={setTemp}
-              step={step}
-              setStep={setStep}
-              onMoveScroll={stepTabs[3].onMoveElement}
-            />
-            <StatisticsBox ref={stepTabs[3].element} data="" />
-          </ConvertStepWrapper>
-        </AnimationProvider>
+        <ConvertStepProvider>
+          <TopContainer>
+            <TitleInputBox>
+              <TitleInput placeholder="제목을 입력해주세요.(n0자)" />
+            </TitleInputBox>
+            <IndicatorBox>
+              <ConvertIndicator
+                step={step}
+                select={select}
+                setSelect={setSelect}
+                stepTabs={stepTabs}
+              />
+              <div style={{ width: '2rem' }} />
+              <SaveButtonBox>
+                <SaveButton>
+                  <SaveFileIcon width={25} />
+                  저장
+                </SaveButton>
+              </SaveButtonBox>
+            </IndicatorBox>
+          </TopContainer>
+          {/* components */}
+          <AnimationProvider>
+            <ConvertStepWrapper>
+              <NovelBox
+                ref={stepTabs[0].element}
+                data=""
+                onScroll={handleScroll}
+                scrollTop={scrollTop}
+              />
+              <CharacterBox
+                data={temp[0]}
+                onScroll={handleScroll}
+                scrollTop={scrollTop}
+                isWrite={step[0]}
+                temp={temp}
+                setTemp={setTemp}
+                onMoveScroll={stepTabs[1].onMoveElement}
+              />
+              <ScriptBox
+                ref={stepTabs[1].element}
+                data={temp[1]}
+                temp={temp}
+                setTemp={setTemp}
+                onMoveScroll={stepTabs[2].onMoveElement}
+              />
+              <StoryboardBox
+                ref={stepTabs[2].element}
+                data={temp[2]}
+                isWrite={step[1]}
+                temp={temp}
+                setTemp={setTemp}
+                onMoveScroll={stepTabs[3].onMoveElement}
+              />
+              <StatisticsBox ref={stepTabs[3].element} data="" />
+            </ConvertStepWrapper>
+          </AnimationProvider>
+        </ConvertStepProvider>
       </BackgroundCover>
     </Background>
   );
@@ -128,7 +123,6 @@ const BackgroundCover = styled.p`
   background-color: rgba(166, 162, 154, 0.4);
   backdrop-filter: blur(3px);
   padding: 0 5vw;
-
   ${css`
     height: calc(100vh - 80px);
   `}

--- a/src/styles/convertBoxStyles.ts
+++ b/src/styles/convertBoxStyles.ts
@@ -75,7 +75,9 @@ export const HighlightedText = styled.span`
   font-weight: bold;
 `;
 
-export const ConvertButton = styled.button<buttonProps>`
+export const ConvertButton = styled.button.attrs((props) => ({
+  disabled: !props.disabled ? true : undefined,
+}))<buttonProps>`
   background: linear-gradient(90deg, #d9d9d9, #b5b5b5);
   color: #ffffff;
   border: none;

--- a/src/styles/convertBoxStyles.ts
+++ b/src/styles/convertBoxStyles.ts
@@ -1,4 +1,6 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+
+type buttonProps = { isWrite: boolean };
 
 export const TitleText = styled.div`
   font-weight: bold;
@@ -25,7 +27,7 @@ export const ScrollText = styled.div`
   white-space: pre-wrap;
   overflow-y: scroll;
   overflow-wrap: break-word;
-`
+`;
 
 export const ScrollTextArea = styled.textarea`
   width: 100%;
@@ -39,11 +41,11 @@ export const ScrollTextArea = styled.textarea`
   overflow-y: scroll;
   overflow-wrap: break-word;
 
-  resize: none;  
+  resize: none;
   &:focus {
     outline: none;
   }
-`
+`;
 
 export const TutorialBox = styled.div`
   width: 80%;
@@ -73,8 +75,8 @@ export const HighlightedText = styled.span`
   font-weight: bold;
 `;
 
-export const ConvertButton = styled.button`
-  background: linear-gradient(90deg, ${({ theme }) => theme.colors.orange}, #84411d);
+export const ConvertButton = styled.button<buttonProps>`
+  background: linear-gradient(90deg, #d9d9d9, #b5b5b5);
   color: #ffffff;
   border: none;
   border-radius: 3rem;
@@ -82,6 +84,16 @@ export const ConvertButton = styled.button`
   cursor: pointer;
   font-size: 1.25rem;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
+
+  ${({ isWrite }) =>
+    isWrite &&
+    css`
+      background: linear-gradient(
+        90deg,
+        ${({ theme }) => theme.colors.orange},
+        #84411d
+      );
+    `}
 `;
 
 export const FileButton = styled.div`
@@ -99,4 +111,4 @@ export const FileButton = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-`
+`;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -31,12 +31,12 @@ export const lightTheme = {
 };
 
 const mediaSize = {
-  xs: "screen and (max-width: '400px')",
-  sm: "screen and (max-width: '640px')",
-  md: "screen and (max-width: '768px')",
-  lg: "screen and (max-width: '1024px')",
-  xl: "screen and (max-width: '1280px')",
-  '2xl': "screen and (max-width: '1536px')",
+  xs: 'screen and (max-width: 400px)',
+  sm: 'screen and (max-width: 640px)',
+  md: 'screen and (max-width: 768px)',
+  lg: 'screen and (max-width: 1024px)',
+  xl: 'screen and (max-width: 1280px)',
+  '2xl': 'screen and (max-width: 1536px)',
 };
 
 // 폰트 크기


### PR DESCRIPTION
### ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요.
변환페이지에서 컴포넌트 간 애니메이션이 동작되도록 구현했습니다.

https://github.com/user-attachments/assets/4b29c904-28c7-40dd-a5e4-a2535b2c2507



### 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
* 웹페이지의 width에 따라서 @media를 적용했습니다. max-width에 따라서 동작하도록 했으며, `theme.ts`에 작성된 `mediaSize.xl`을 사용했습니다.
* 소설, 대본, 스토리보드, 통계 컴포넌트를 감싸고 있는 부모 컴포넌트(`ConvertStepWrapper`)에서 스크롤이 보이지 않도록 수정했습니다.
* 배경의 height를 수정했습니다. `100vh -> 100vh - 80px`
* 원고를 작성하고 등장인물 인식 전, 원고가 비어있는 경우, 버튼을 활성화하지 않도록 구현했습니다.

![image](https://github.com/user-attachments/assets/44f64f73-3803-4fb2-9d76-62e7203bfbd8)

![image](https://github.com/user-attachments/assets/a64ac183-3dda-4f5d-9980-253fa44ec64b)


### 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 첨부해주세요.
1. 코드를 작성하면서 재사용성이 높다고 판단된 animation(변환 페이지를 넘어갈 때 적용되는 애니메이션)과 step(사용자의 단계 달성여부 표시)을 전역 변수로 선언하여 사용하고 있습니다. 관련 함수 모두 context를 사용하여 구현했습니다. (context 폴더 참고)
  * **step 변수에 context 도입 배경**: context를 도입한 가장 큰 이유는 아래 사진과 같은데요, 변환 페이지의 컴포넌트를 감싸고 있는 ConveerPage.tsx에서 상태를 정의하고 모든 하위 컴포넌트에 state 변수, 함수를 props로 전달해야 한다는 점이 코드의 가독성을 헤친다고 보가습니다. 아래 props를 보면, step과 setStep을 전달해주고 있습니다.
  
  ![image](https://github.com/user-attachments/assets/126a8d86-eaf7-4d28-be57-b17ed5faeff4)

 * **animation에 context 도입 배경**: 애니메이션의 동작 과정을 설명해보자면, 버튼을 클릭하면 ①다음 컴포넌트가 있는 위치로 스크롤 이동 후에 ②다음 컴포넌트를 서서히 보여줍니다. 즉, 힌 컴포넌트에서 이벤트가 발생했을 때 같은 부모를 가진 다른 자식 컴포넌트에 영향을 줘야합니다. 선택지는 2가지가 있었습니다. ①관련 상태를 부모 컴포넌트인 ConvertPage에서 관리하고 props로 함수를 넘겨주는 방식이 있고, ②애니메이션과 애니메이션을 적용할 컨트롤 변수를 **전역적으로** 선언하는 방법입니다. 
  1번째 방법은 스파게티 코드를 생산해낼 것 같아서 2번째 방법을 채택했습니다.
  
  💬 고민이 되는 점은, 전역으로 상태를 관리하는 방법은 다양하다는 것입니다. 제가 선택한 context가 있고, 이것 외에도 recoil, redux, reducer... 어떤 라이브러리를 선택할지는 프로젝트의 규모나 코드의 복잡도를 고려하여 개발자가 선택하기 나름인 것 같아요. 저는 단순하게 구현할 수 있는 context를 선택하긴 했습니다만, 다른 라이브러리를 공부해보고 우리 프로젝트에 적용하기 괜찮은 라이브러리가 있다면 그걸로 변경할 예정입니다.
 **[참고자료]** [blog) 상태관리 라이브러리 차이점](https://velog.io/@velopert/react-context-tutorial#%EC%A0%84%EC%97%AD-%EC%83%81%ED%83%9C-%EA%B4%80%EB%A6%AC-%EB%9D%BC%EC%9D%B4%EB%B8%8C%EB%9F%AC%EB%A6%AC%EB%8A%94-%EC%96%B8%EC%A0%9C-%EC%8D%A8%EC%95%BC-%ED%95%A0%EA%B9%8C)

결론적으로 props를 줄일 수 있었습니다.
![image](https://github.com/user-attachments/assets/051cf401-1b45-485d-910c-824343370f16)
그럼 여기서 보이는 temp에 대해 설명하겠습니다.

2. 변환 페이지에서의 애니메이션과 흐름을 구현하기 위해 temp 상태 변수를 만들었습니다. 저는 컴포넌트에 있는 data props를 API 호출하여 반환된 값을 data로 전달한다고 생각했거든요. 하지만 API가 개발되기 전이니까 우선은 temp, setTemp를 임시적으로 사용했습니다. 각각의 컴포넌트에 있는 data props는 temp 값에 의존합니다. **API를 연결하는 과정에 없앨 예정입니다.**

3. 한 가지 오류가 있습니다. 모든 과정을 거치고 사용자가 중간에 소설 컴포넌트의 input을 비우면 인디케이터 '소설' 아이템이 off로 되어서 화면상 문제가 있는것처럼 보이긴 합니다. 이 부분은 다음 PR 때 수정하겠습니다.
![image](https://github.com/user-attachments/assets/16c34550-3d20-4ca9-a777-e1d56a9524e2)


### ➕ 관련 이슈 링크
- #23

---
### 📝 Assignee를 위한 CheckList
- [x] 변환페이지에서의 인디케이터 애니메이션 구현 확인
- [x] 웹페이지 배경의 height 잘 맞는지 확인
- [x] 제목 작성 input과 인디케이터의 레이아웃이 잘 들어맞는지 확인
- [x] 전체적인 레이아웃에 이상이 없는지 확인
