### PR TITLE
[Feat/main page] 메인페이지 샘플 데이터 변환 API 연결

### DIFF
--- a/src/assets/icons/main_logo_icon.svg
+++ b/src/assets/icons/main_logo_icon.svg
@@ -1,0 +1,54 @@
+<svg width="189" height="249" viewBox="0 0 189 249" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_i_587_1369)">
+<circle cx="86.7382" cy="86.5023" r="86.5023" fill="url(#paint0_linear_587_1369)"/>
+</g>
+<rect x="96.9814" y="128.914" width="22.4442" height="95.2429" rx="3" transform="rotate(-30 96.9814 128.914)" fill="url(#paint1_linear_587_1369)"/>
+<path d="M122.319 115.942C121.773 114.997 121.784 113.83 122.348 112.894L128.051 103.426L132.043 96.7991C133.222 94.842 136.069 94.8684 137.211 96.847L182.182 174.739C182.76 175.74 182.711 176.984 182.057 177.937C178.12 183.677 175.385 187.665 171.749 192.966C170.501 194.786 167.78 194.682 166.676 192.771L122.319 115.942Z" fill="#58613E"/>
+<path d="M92.5152 133.149C91.9693 132.203 90.9529 131.629 89.8614 131.649L71.0747 131.998C68.7904 132.041 67.39 134.519 68.5323 136.498L113.503 214.39C114.081 215.391 115.182 215.971 116.334 215.881L134.506 214.468C136.707 214.297 137.976 211.889 136.872 209.977L92.5152 133.149Z" fill="#B18E7B"/>
+<ellipse cx="99.4441" cy="110.464" rx="16.3212" ry="6.93651" transform="rotate(-30 99.4441 110.464)" fill="#5A574B"/>
+<rect x="96.9814" y="128.914" width="22.4442" height="95.2429" rx="2" transform="rotate(-30 96.9814 128.914)" fill="url(#paint2_linear_587_1369)"/>
+<path d="M122.024 115.432C121.661 114.801 121.668 114.023 122.043 113.4L128.051 103.426L132.918 95.3467C133.704 94.042 135.602 94.0596 136.363 95.3787L182.497 175.285C182.882 175.952 182.849 176.783 182.413 177.419C177.96 183.911 175.066 188.131 170.852 194.274C170.02 195.488 168.205 195.419 167.47 194.145L122.024 115.432Z" fill="#58613E"/>
+<path d="M92.2203 132.638C91.8564 132.008 91.1788 131.625 90.4511 131.638L69.3795 132.03C67.8566 132.058 66.923 133.71 67.6846 135.029L113.819 214.936C114.204 215.603 114.938 215.99 115.706 215.93L136.088 214.345C137.555 214.231 138.401 212.626 137.665 211.351L92.2203 132.638Z" fill="#B18E7B"/>
+<ellipse cx="99.4441" cy="110.464" rx="16.3212" ry="6.93651" transform="rotate(-30 99.4441 110.464)" fill="#5A574B"/>
+<g clip-path="url(#clip0_587_1369)">
+<path d="M179.203 247.454L139.173 222.494L177.602 200.307L179.203 247.454Z" fill="url(#paint3_linear_587_1369)"/>
+</g>
+<path d="M109.858 66.2866L114.077 92.4396" stroke="#4F493D" stroke-width="5" stroke-linecap="round"/>
+<path d="M54.1772 99.1626L75.3121 115.066" stroke="#4F493D" stroke-width="5" stroke-linecap="round"/>
+<path d="M59.3177 85.9649C59.3177 85.9649 70.6226 98.9798 83.982 74.8798C97.3415 50.7798 108.646 63.7947 108.646 63.7947" stroke="url(#paint4_linear_587_1369)" stroke-width="5" stroke-linecap="round"/>
+<defs>
+<filter id="filter0_i_587_1369" x="-3.76416" y="-4" width="177.005" height="177.005" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feMorphology radius="10" operator="erode" in="SourceAlpha" result="effect1_innerShadow_587_1369"/>
+<feOffset dx="-4" dy="-4"/>
+<feGaussianBlur stdDeviation="25"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.545098 0 0 0 0 0.462745 0 0 0 0 0.423529 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_587_1369"/>
+</filter>
+<linearGradient id="paint0_linear_587_1369" x1="86.7382" y1="0" x2="86.7382" y2="173.005" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFFCF5"/>
+<stop offset="0.575" stop-color="#FFFEFB"/>
+<stop offset="1" stop-color="white" stop-opacity="0.5"/>
+</linearGradient>
+<linearGradient id="paint1_linear_587_1369" x1="108.204" y1="128.914" x2="108.204" y2="224.157" gradientUnits="userSpaceOnUse">
+<stop stop-color="#BB4E11"/>
+</linearGradient>
+<linearGradient id="paint2_linear_587_1369" x1="108.204" y1="128.914" x2="108.204" y2="224.157" gradientUnits="userSpaceOnUse">
+<stop stop-color="#BB4E11"/>
+</linearGradient>
+<linearGradient id="paint3_linear_587_1369" x1="151.449" y1="199.383" x2="179.203" y2="247.454" gradientUnits="userSpaceOnUse">
+<stop offset="0.395" stop-color="#C8C2B7"/>
+<stop offset="1" stop-color="#FFFCF5"/>
+</linearGradient>
+<linearGradient id="paint4_linear_587_1369" x1="59.3177" y1="85.9649" x2="108.646" y2="63.7947" gradientUnits="userSpaceOnUse">
+<stop stop-color="#EA7333"/>
+<stop offset="1" stop-color="#84411D"/>
+</linearGradient>
+<clipPath id="clip0_587_1369">
+<rect width="40.8516" height="50.5781" fill="white" transform="translate(138.353 198.422)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/icons/nav_logo_icon.svg
+++ b/src/assets/icons/nav_logo_icon.svg
@@ -1,0 +1,49 @@
+<svg width="140" height="140" viewBox="0 0 140 140" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_i_526_566)">
+<circle cx="65.6358" cy="48.6358" r="48.6358" fill="#FFFCF5"/>
+</g>
+<rect x="71.395" y="72.4819" width="12.6192" height="53.5502" rx="3" transform="rotate(-30 71.395 72.4819)" fill="url(#paint0_linear_526_566)"/>
+<path d="M86.0288 65.8594C85.4829 64.914 85.4937 63.7466 86.0571 62.8114L88.8642 58.1513L89.9597 56.3326C91.1386 54.3756 93.9852 54.402 95.1276 56.3806L118.885 97.5303C119.463 98.5309 119.414 99.7748 118.761 100.728C117.217 102.979 115.986 104.774 114.612 106.777C113.363 108.597 110.643 108.492 109.539 106.581L86.0288 65.8594Z" fill="#58613E"/>
+<path d="M69.2714 75.5337C68.7256 74.5883 67.7092 74.014 66.6177 74.0342L59.0555 74.1746C56.7712 74.2171 55.3708 76.6955 56.5131 78.6741L80.2709 119.824C80.8486 120.824 81.9496 121.404 83.1016 121.315L90.4164 120.746C92.6169 120.575 93.8855 118.167 92.782 116.255L69.2714 75.5337Z" fill="#B18E7B"/>
+<ellipse cx="72.78" cy="62.1081" rx="9.17657" ry="3.90004" transform="rotate(-30 72.78 62.1081)" fill="#5A574B"/>
+<rect x="71.395" y="72.4819" width="12.6192" height="53.5502" rx="2" transform="rotate(-30 71.395 72.4819)" fill="url(#paint1_linear_526_566)"/>
+<path d="M85.7339 65.3486C85.37 64.7183 85.3772 63.9401 85.7527 63.3166L88.8642 58.1513L90.8346 54.8803C91.6205 53.5756 93.5182 53.5932 94.2798 54.9123L119.201 98.0762C119.586 98.7433 119.553 99.5734 119.117 100.209C117.065 103.201 115.588 105.354 113.714 108.085C112.882 109.299 111.068 109.229 110.333 107.955L85.7339 65.3486Z" fill="#58613E"/>
+<path d="M68.9765 75.0229C68.6126 74.3926 67.935 74.0098 67.2074 74.0233L57.3603 74.2061C55.8374 74.2344 54.9038 75.8867 55.6654 77.2058L80.5861 120.37C80.9712 121.037 81.7052 121.423 82.4732 121.364L91.9982 120.623C93.4652 120.509 94.311 118.903 93.5753 117.629L68.9765 75.0229Z" fill="#B18E7B"/>
+<ellipse cx="72.78" cy="62.1081" rx="9.17657" ry="3.90004" transform="rotate(-30 72.78 62.1081)" fill="#5A574B"/>
+<g clip-path="url(#clip0_526_566)">
+<path d="M117.624 139.131L95.1172 125.097L116.724 112.623L117.624 139.131Z" fill="url(#paint2_linear_526_566)"/>
+</g>
+<path d="M78.6353 37.2695L81.0069 51.974" stroke="#4F493D" stroke-width="3" stroke-linecap="round"/>
+<path d="M47.3286 55.7539L59.2117 64.6955" stroke="#4F493D" stroke-width="3" stroke-linecap="round"/>
+<path d="M50.2186 48.3338C50.2186 48.3338 56.5748 55.6514 64.0861 42.1012C71.5975 28.551 77.9536 35.8686 77.9536 35.8686" stroke="url(#paint3_linear_526_566)" stroke-width="3" stroke-linecap="round"/>
+<defs>
+<filter id="filter0_i_526_566" x="13" y="-4" width="101.271" height="101.271" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feMorphology radius="10" operator="erode" in="SourceAlpha" result="effect1_innerShadow_526_566"/>
+<feOffset dx="-4" dy="-4"/>
+<feGaussianBlur stdDeviation="25"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.545098 0 0 0 0 0.462745 0 0 0 0 0.423529 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_526_566"/>
+</filter>
+<linearGradient id="paint0_linear_526_566" x1="77.7046" y1="72.4819" x2="77.7046" y2="126.032" gradientUnits="userSpaceOnUse">
+<stop stop-color="#BB4E11"/>
+</linearGradient>
+<linearGradient id="paint1_linear_526_566" x1="77.7046" y1="72.4819" x2="77.7046" y2="126.032" gradientUnits="userSpaceOnUse">
+<stop stop-color="#BB4E11"/>
+</linearGradient>
+<linearGradient id="paint2_linear_526_566" x1="102.019" y1="112.103" x2="117.624" y2="139.131" gradientUnits="userSpaceOnUse">
+<stop offset="0.395" stop-color="#C8C2B7"/>
+<stop offset="1" stop-color="#FFFCF5"/>
+</linearGradient>
+<linearGradient id="paint3_linear_526_566" x1="50.2186" y1="48.3338" x2="77.9536" y2="35.8686" gradientUnits="userSpaceOnUse">
+<stop stop-color="#EA7333"/>
+<stop offset="1" stop-color="#84411D"/>
+</linearGradient>
+<clipPath id="clip0_526_566">
+<rect width="22.9688" height="28.4375" fill="white" transform="translate(94.6562 111.562)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/component/base/Navbar.tsx
+++ b/src/component/base/Navbar.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import LoginModal from './LoginModal';
+import { ReactComponent as NavLogo } from '../../assets/icons/nav_logo_icon.svg';
 
 const NavBar = () => {
   const navigate = useNavigate();
@@ -25,7 +26,7 @@ const NavBar = () => {
   return (
     <Container>
       <LoginModal isOpen={modalIsOpen} setModalIsOpen={setModalIsOpen} />
-      <Logo />
+      <NavLogo width={50} />
       <Text onClick={navigateConvertScript}>대본 변환</Text>
       <div style={{ flex: 1 }} />
       {!isLogin ? (
@@ -57,14 +58,6 @@ const Container = styled.div`
   padding: 0 50px;
   gap: 30px;
   background-color: ${({ theme }) => theme.colors.olive};
-`;
-
-// component
-const Logo = styled.image`
-  width: 50px;
-  height: 50px;
-  border-radius: 50px;
-  background-color: white;
 `;
 
 export default NavBar;

--- a/src/component/mainpage/MainIndicator.tsx
+++ b/src/component/mainpage/MainIndicator.tsx
@@ -78,6 +78,12 @@ const IndicatorShape = styled.div<boxProps>`
       height: 2.5rem;
       background-color: ${({ theme }) => theme.colors.orange};
     `}
+
+  transition: width 0.5s ease, height 0.5s ease;
+  &:hover {
+    width: 3.5rem;
+    height: 3.5rem;
+  }
 `;
 
 export default MainIndicator;

--- a/src/component/mainpage/MainPageFirstBox.tsx
+++ b/src/component/mainpage/MainPageFirstBox.tsx
@@ -1,14 +1,22 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 import { TitleText, SubTitleText, ContentText } from '../../styles/mainStyles';
+import { ReactComponent as MainLogo } from '../../assets/icons/main_logo_icon.svg';
+import { motion } from 'framer-motion';
 
 const MainPageFirstBox = () => {
   const blank = '\u00A0\u00A0\u00A0';
+
   return (
     <LayoutWrapper>
       <TitleText>: Plotter</TitleText>
       <IntroduceBox>
-        <ServiceLogo />
+        <ServiceLogoBox>
+          <Circle type={'big'} />
+          <Circle type={'medium'} />
+          <Circle type={'small'} />
+          <MainLogo style={{ position: 'relative' }} />
+        </ServiceLogoBox>
         <ContentBox>
           <SubTitleContentBox>
             <SubTitleText page={'first'}>소설을 대본으로</SubTitleText>
@@ -32,6 +40,10 @@ const MainPageFirstBox = () => {
       </IntroduceBox>
     </LayoutWrapper>
   );
+};
+
+type typeProps = {
+  type: string;
 };
 
 // container
@@ -58,12 +70,63 @@ const SubTitleContentBox = styled.div`
   gap: 1rem;
 `;
 
+const ServiceLogoBox = styled.div`
+  position: relative;
+`;
+
+// keyframes
+const Gradient = keyframes`
+    0% {
+      transform: translateY(0px);
+    }
+    50%{
+      transform: translateY(7px);
+    }
+    100% {
+      transform: translateY(0px);
+    }
+`;
+
 // compoenent
-const ServiceLogo = styled.image`
-  width: 15rem;
-  height: 15rem;
-  border-radius: 1rem;
-  background-color: gray;
+const Circle = styled(motion.div)<typeProps>`
+  position: absolute;
+  border-radius: 50rem;
+  opacity: 0.7;
+
+  ${({ type, theme }) => {
+    switch (type) {
+      case 'small':
+        return css`
+          width: 4rem;
+          height: 4rem;
+          background-color: ${theme.colors.ivory};
+          top: 14rem;
+          left: 8rem;
+
+          animation: ${Gradient} 3s ease-in-out infinite;
+        `;
+      case 'medium':
+        return css`
+          width: 5rem;
+          height: 5rem;
+          background-color: ${theme.colors.orange};
+          top: -2rem;
+          left: 8rem;
+
+          animation: ${Gradient} 5s ease-in-out infinite;
+        `;
+      case 'big':
+        return css`
+          width: 8rem;
+          height: 8rem;
+          background-color: ${theme.colors.olive};
+          top: 8rem;
+          left: -3rem;
+
+          animation: ${Gradient} 7s ease-in-out infinite;
+        `;
+    }
+  }}
 `;
 
 export default MainPageFirstBox;

--- a/src/component/mainpage/MainPageSecondBox.tsx
+++ b/src/component/mainpage/MainPageSecondBox.tsx
@@ -7,6 +7,9 @@ import {
   ExplainGridBox,
 } from '../../styles/mainStyles';
 import { ReactComponent as ArrowRightIcon } from '../../assets/icons/arrow_right_icon.svg';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../../utils/queryKeys';
+import axios from 'axios';
 
 const MainPageSecondBox = () => {
   const [select, setSelect] = useState<number>(0);
@@ -17,16 +20,26 @@ const MainPageSecondBox = () => {
     '샘플내용3',
     '샘플내용4',
   ];
-  const resultNovel: string[] = [
-    '결과내용1',
-    '결과내용2',
-    '결과내용3',
-    '결과내용4',
-  ]; //임시
 
   useEffect(() => {
     setIsClick(false); // 결과 text 초기화
   }, [select]);
+
+  // fetch data
+  const fetchDemo = async (select: number) => {
+    const result = await axios.get(
+      `/spring/scripts/sample/SAMPLE${select + 1}`
+    );
+    const data = result.data;
+
+    return data;
+  };
+
+  const demoQuery = useQuery({
+    queryKey: [queryKeys.demo, select],
+    queryFn: () => fetchDemo(select),
+    enabled: !!isClick, // isClick이 true일 때만 실행
+  });
 
   // 설명 박스의 내용
   const explainContents = () => {
@@ -53,21 +66,25 @@ const MainPageSecondBox = () => {
 
   return (
     <LayoutWrapper>
-      <SampleContainer>
-        <SampleNovelSelector select={select} setSelect={setSelect} />
-        <TextBox>{sampleNovel[select]}</TextBox>
-        <ConvertButton onClick={() => setIsClick(true)}>
-          대본 변환
-        </ConvertButton>
-      </SampleContainer>
-      <ArrowRightIcon />
-      <SampleContainer>
-        <div style={{ height: '30px' }} />
-        <TextBox>{isClick && resultNovel[select]}</TextBox>
-        <div style={{ height: '2.5rem' }} />
-      </SampleContainer>
-      {/* explain */}
-      <ExplainGridBox page={'second'}>{explainContents()}</ExplainGridBox>
+      {!demoQuery.isLoading && (
+        <>
+          <SampleContainer>
+            <SampleNovelSelector select={select} setSelect={setSelect} />
+            <TextBox>{sampleNovel[select]}</TextBox>
+            <ConvertButton onClick={() => setIsClick(true)}>
+              대본 변환
+            </ConvertButton>
+          </SampleContainer>
+          <ArrowRightIcon />
+          <SampleContainer>
+            <div style={{ height: '30px' }} />
+            <TextBox>{isClick && demoQuery.data.result.sampleScript} </TextBox>
+            <div style={{ height: '2.5rem' }} />
+          </SampleContainer>
+          {/* explain */}
+          <ExplainGridBox page={'second'}>{explainContents()}</ExplainGridBox>
+        </>
+      )}
     </LayoutWrapper>
   );
 };
@@ -92,6 +109,12 @@ const TextBox = styled.div`
   background-color: white;
   border-radius: 1.5rem;
   padding: 1rem;
+
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+
+  line-height: 1.5;
 `;
 
 // component

--- a/src/component/mainpage/MainPageThirdBox.tsx
+++ b/src/component/mainpage/MainPageThirdBox.tsx
@@ -97,7 +97,7 @@ const ExampleBox = styled.div`
 `;
 
 // component
-const ExampleImage = styled.image`
+const ExampleImage = styled.img`
   width: 30vw;
   height: 45vh;
   border-radius: 0.5rem;

--- a/src/utils/queryKeys.ts
+++ b/src/utils/queryKeys.ts
@@ -1,3 +1,4 @@
 export const queryKeys = {
   user: ['user'],
+  demo: ['demo'],
 };


### PR DESCRIPTION
### ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요.
* 샘플 데이터 API 연결

### 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
* 나브바 로고 변경
* 메인페이지 첫 번째 박스 로고 애니메이션 적용
* 인디케이터 hover시에 애니메이션 적용
* image 태그 인식되지 않는 경고 -> img 태그로 수정

### 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 첨부해주세요.
* 백엔드 팀 왈, pre 태그를 사용하면 프론트 단에서 텍스트에 /t /n이 string으로 출력되지 않고 잘 적용된다고 했습니다. 하지만 저는 css의 설정으로 해결했답니다. 
* input의 width가 고정되어 있어서 /t /n을 적용해도 가독성이 좋은 편은 아니네요.
  * 이대로 사용자에게 보여줘도 괜찮을지?
  * overflow-x를 주면 사용자가 스크롤을 해야 하지만 우리가 원하는 출력 결과로 보여줄 수 있어요.
* 입력값은 아직 샘플내용 1, 샘플내용2 ...로 보이는 것이 맞습니다. 백엔드 단에서 샘플 API 요청시 사용한 원본 소설을 받지 못했어요. 아마 어떤 샘플을 사용할지 정해지면 백엔드 팀에서 보내줄 것 같습니다.

### ➕ 관련 이슈 링크
- #13 
- #40

---
### 📝 Assignee를 위한 CheckList
- [ ] 샘플데이터 API 연결 확인
- [ ] 메인페이지 첫 번째 박스 로고 애니메이션 동작 확인
