### PR TITLE
[Feat/refresh token] 토큰 재발급 API 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import { StyledToastConatiner } from './styles/ToastStyle';
 import 'react-toastify/dist/ReactToastify.css';
 import { ConvertDataProvider } from './context/convertDataContext';
 import { MainPageAnimateProvider } from './context/mainAnimationContext';
+import { useTokenModal } from './context/tokenModalContext';
+import TokenExpireModal from './component/base/TokenExpireModal';
 
 // initialize queryClient
 const queryClient = new QueryClient({
@@ -21,6 +23,8 @@ const queryClient = new QueryClient({
 });
 
 const App = () => {
+  const { modalIsOpen, closeModal } = useTokenModal();
+
   return (
     <>
       <MainPageAnimateProvider>
@@ -38,6 +42,8 @@ const App = () => {
         </ConvertDataProvider>
       </MainPageAnimateProvider>
       <StyledToastConatiner limit={1} />
+      {/* token expire modal */}
+      <TokenExpireModal isOpen={modalIsOpen} setModalIsOpen={closeModal} />
     </>
   );
 };

--- a/src/component/base/LogoutModal.tsx
+++ b/src/component/base/LogoutModal.tsx
@@ -23,6 +23,7 @@ const LogoutModal = ({ isOpen, setModalIsOpen, setIsLogin }: ModalProps) => {
       setIsLogin(false);
       Toast.success(toastText.logoutSuccess);
     } else {
+      setModalIsOpen(false);
       Toast.error(toastText.logoutError);
     }
   };
@@ -51,6 +52,7 @@ const LogoutModal = ({ isOpen, setModalIsOpen, setIsLogin }: ModalProps) => {
             네
           </Button>
           <Button
+            onClick={() => setModalIsOpen(false)}
             style={{
               backgroundColor: theme.colors.beige,
               color: theme.colors.darkBrown,

--- a/src/component/base/TokenExpireModal.tsx
+++ b/src/component/base/TokenExpireModal.tsx
@@ -1,0 +1,101 @@
+import Modal from 'react-modal';
+import styled from 'styled-components';
+import theme from '../../styles/theme';
+import { useAuth } from '../../hooks/useAuth';
+import { ModalCustomStyle } from '../../styles/mainStyles';
+import { Toast } from '../../styles/ToastStyle';
+import { toastText } from '../../utils/toastText';
+
+interface ModalProps {
+  isOpen: boolean;
+  setModalIsOpen: (value: boolean) => void;
+}
+
+const TokenExpireModal = ({ isOpen, setModalIsOpen }: ModalProps) => {
+  const { logout } = useAuth();
+  console.log('ㅇㅇ;', isOpen, setModalIsOpen);
+
+  const handleLogout = async () => {
+    const complete = await logout();
+    // 로그아웃 성공 여부 처리
+    if (complete) {
+      setModalIsOpen(false);
+      Toast.success(toastText.logoutSuccess);
+    } else {
+      setModalIsOpen(false);
+      Toast.error(toastText.logoutError);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onRequestClose={() => setModalIsOpen(false)}
+      style={ModalCustomStyle}
+      ariaHideApp={false}
+      shouldCloseOnOverlayClick={true}
+    >
+      {/* exit */}
+      <ExitContainer></ExitContainer>
+      {/* content */}
+      <LayoutContainer>
+        <Text style={{ color: theme.colors.darkBrown }}>
+          오랫동안 접속하지 않아 로그아웃 처리가 되었어요! {'\n'}
+          다시 재로그인 하시겠어요?
+        </Text>
+        <div style={{ height: '80px' }} />
+        <ButtonBox>
+          <Button
+            onClick={handleLogout}
+            style={{ backgroundColor: theme.colors.olive }}
+          >
+            네
+          </Button>
+          <Button
+            style={{
+              backgroundColor: theme.colors.beige,
+              color: theme.colors.darkBrown,
+            }}
+          >
+            아니요
+          </Button>
+        </ButtonBox>
+      </LayoutContainer>
+    </Modal>
+  );
+};
+
+// text
+const Text = styled.span`
+  font-size: 1rem;
+`;
+
+// container
+const ExitContainer = styled.div`
+  display: flex;
+  height: 2rem;
+`;
+
+const LayoutContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const ButtonBox = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+`;
+
+// conponent
+const Button = styled.button`
+  text-align: center;
+  width: 10rem;
+  padding: 0.8rem 0;
+  font-size: 0.8rem;
+  border-radius: 1rem;
+  box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.3);
+`;
+
+export default TokenExpireModal;

--- a/src/component/base/TokenExpireModal.tsx
+++ b/src/component/base/TokenExpireModal.tsx
@@ -1,10 +1,7 @@
 import Modal from 'react-modal';
 import styled from 'styled-components';
 import theme from '../../styles/theme';
-import { useAuth } from '../../hooks/useAuth';
 import { ModalCustomStyle } from '../../styles/mainStyles';
-import { Toast } from '../../styles/ToastStyle';
-import { toastText } from '../../utils/toastText';
 
 interface ModalProps {
   isOpen: boolean;
@@ -12,19 +9,9 @@ interface ModalProps {
 }
 
 const TokenExpireModal = ({ isOpen, setModalIsOpen }: ModalProps) => {
-  const { logout } = useAuth();
-  console.log('ㅇㅇ;', isOpen, setModalIsOpen);
-
-  const handleLogout = async () => {
-    const complete = await logout();
-    // 로그아웃 성공 여부 처리
-    if (complete) {
-      setModalIsOpen(false);
-      Toast.success(toastText.logoutSuccess);
-    } else {
-      setModalIsOpen(false);
-      Toast.error(toastText.logoutError);
-    }
+  const handleButtonClick = async () => {
+    setModalIsOpen(false);
+    window.location.reload(); // 페이지 리로드, 모든 상태 초기화
   };
 
   return (
@@ -33,31 +20,23 @@ const TokenExpireModal = ({ isOpen, setModalIsOpen }: ModalProps) => {
       onRequestClose={() => setModalIsOpen(false)}
       style={ModalCustomStyle}
       ariaHideApp={false}
-      shouldCloseOnOverlayClick={true}
+      shouldCloseOnOverlayClick={false}
     >
       {/* exit */}
       <ExitContainer></ExitContainer>
       {/* content */}
       <LayoutContainer>
         <Text style={{ color: theme.colors.darkBrown }}>
-          오랫동안 접속하지 않아 로그아웃 처리가 되었어요! {'\n'}
-          다시 재로그인 하시겠어요?
+          오랫동안 서비스를 사용하지 않아 로그아웃이 되었어요. <br />
+          다시 로그인을 해서 서비스를 이용해주세요.
         </Text>
         <div style={{ height: '80px' }} />
         <ButtonBox>
           <Button
-            onClick={handleLogout}
+            onClick={handleButtonClick}
             style={{ backgroundColor: theme.colors.olive }}
           >
-            네
-          </Button>
-          <Button
-            style={{
-              backgroundColor: theme.colors.beige,
-              color: theme.colors.darkBrown,
-            }}
-          >
-            아니요
+            알겠습니다!
           </Button>
         </ButtonBox>
       </LayoutContainer>
@@ -68,6 +47,7 @@ const TokenExpireModal = ({ isOpen, setModalIsOpen }: ModalProps) => {
 // text
 const Text = styled.span`
   font-size: 1rem;
+  text-align: center;
 `;
 
 // container

--- a/src/component/convert/script/SceneList.tsx
+++ b/src/component/convert/script/SceneList.tsx
@@ -33,16 +33,18 @@ const SceneList = () => {
   };
 
   return (
-    <Container>
-      {script.scene.map((scene, sceneIndex) => (
-        <SceneItem
-          key={scene.scene_num}
-          scene={scene}
-          sceneIndex={sceneIndex}
-          onContentChange={handleContentChange}
-        />
-      ))}
-    </Container>
+    script && (
+      <Container>
+        {script.scene.map((scene, sceneIndex) => (
+          <SceneItem
+            key={scene.scene_num}
+            scene={scene}
+            sceneIndex={sceneIndex}
+            onContentChange={handleContentChange}
+          />
+        ))}
+      </Container>
+    )
   );
 };
 

--- a/src/context/tokenModalContext.tsx
+++ b/src/context/tokenModalContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+type ModalContextType = {
+  modalIsOpen: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+};
+
+const ModalContext = createContext<ModalContextType | undefined>(undefined);
+
+export const ModalProvider = ({ children }: { children: React.ReactNode }) => {
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+
+  const openModal = () => setModalIsOpen(true);
+  const closeModal = () => setModalIsOpen(false);
+
+  return (
+    <ModalContext.Provider value={{ modalIsOpen, openModal, closeModal }}>
+      {children}
+    </ModalContext.Provider>
+  );
+};
+
+const useTokenModal = (): ModalContextType => {
+  const context = useContext(ModalContext);
+  if (!context) {
+    throw new Error('useModal must be used within a ModalProvider');
+  }
+  return context;
+};
+
+export { useTokenModal };

--- a/src/hooks/useAxiosInstance.ts
+++ b/src/hooks/useAxiosInstance.ts
@@ -1,0 +1,145 @@
+import axios, { AxiosError, AxiosRequestConfig } from 'axios';
+import { useUser } from './useUser';
+import { useAuth } from './useAuth';
+import { useTokenModal } from '../context/tokenModalContext';
+
+interface CustomAxiosRequestConfig extends AxiosRequestConfig {
+  _retry?: boolean;
+}
+
+// access token 재발급
+export const useAxiosInstances = () => {
+  const { getTokenUser, clearUser } = useUser();
+  const { openModal } = useTokenModal();
+
+  const createAxiosInstance = (reissue: () => Promise<boolean | undefined>) => {
+    const axiosInstance = axios.create();
+    const { accessToken } = getTokenUser();
+    axiosInstance.interceptors.request.use(
+      (config) => {
+        if (accessToken && config.headers) {
+          const { accessToken } = getTokenUser();
+          config.headers['X-AUTH-TOKEN'] = accessToken; // 액세스 토큰 설정
+        }
+
+        return config;
+      },
+      (err) => {
+        return Promise.reject(err);
+      }
+    );
+
+    axiosInstance.interceptors.response.use(
+      (response) => {
+        return response; // success
+      },
+      async (err: unknown) => {
+        // error
+        if (err instanceof AxiosError) {
+          const originRequest = err.config as CustomAxiosRequestConfig;
+
+          if (
+            originRequest &&
+            err.response?.data.error.code == 'TOKEN403' &&
+            !originRequest._retry
+          ) {
+            try {
+              const result = await reissue(); // 토큰 재발급, result(boolean) 사용
+              if (!result) {
+                return Promise.resolve({
+                  data: {
+                    result: {
+                      isSuccess: false,
+                      message: '토큰 재발급 실패',
+                    },
+                  },
+                });
+              } else if (originRequest.headers) {
+                const { accessToken } = getTokenUser();
+                originRequest.headers['X-AUTH-TOKEN'] = accessToken;
+              }
+              originRequest._retry = true;
+              try {
+                const newResult = await axiosInstance.request(originRequest); // 요청 재시도
+                return newResult;
+              } catch (retryError) {
+                return Promise.reject(retryError);
+              }
+            } catch (err) {
+              console.log(err);
+              return Promise.reject(err);
+            }
+          }
+        }
+      }
+    );
+
+    return axiosInstance;
+  };
+
+  // access token과 request token 로그아웃 처리
+  const createAxiosInstanceTwoTkn = (
+    reissue: () => Promise<boolean | undefined>
+  ) => {
+    const axiosInstanceTwoTkn = axios.create();
+    const { accessToken, refreshToken } = getTokenUser();
+
+    axiosInstanceTwoTkn.interceptors.request.use(
+      (config) => {
+        if (accessToken && refreshToken && config.headers) {
+          const { accessToken, refreshToken } = getTokenUser();
+          config.headers['X-AUTH-TOKEN'] = accessToken;
+          config.headers['refresh-Token'] = refreshToken;
+        }
+
+        return config;
+      },
+      (err) => {
+        return Promise.reject(err);
+      }
+    );
+
+    axiosInstanceTwoTkn.interceptors.response.use(
+      (response) => {
+        return response; // success
+      },
+      async (err: unknown) => {
+        // error
+        if (err instanceof AxiosError) {
+          const originRequest = err.config as CustomAxiosRequestConfig;
+          if (err.response?.data.code == 'TOKEN404') {
+            clearUser();
+            openModal(); // 로그아웃 처리 모달 띄우기
+            return false;
+          } else if (
+            originRequest &&
+            err.response?.data.error.code == 'TOKEN403' &&
+            !originRequest._retry
+          ) {
+            try {
+              const result = await reissue(); // 토큰 재발급, result(boolean) 사용 x
+              if (originRequest.headers) {
+                const { accessToken, refreshToken } = getTokenUser();
+                originRequest.headers['X-AUTH-TOKEN'] = accessToken;
+                originRequest.headers['refresh-Token'] = refreshToken;
+              }
+
+              originRequest._retry = true;
+
+              const newResuit = await axiosInstanceTwoTkn(originRequest); // 요청 재시도
+              return newResuit;
+            } catch (err) {
+              return Promise.reject(err);
+            }
+          }
+        }
+      }
+    );
+
+    return axiosInstanceTwoTkn;
+  };
+  return {
+    createAxiosInstance,
+    createAxiosInstanceTwoTkn,
+  };
+};

--- a/src/hooks/useConvert.ts
+++ b/src/hooks/useConvert.ts
@@ -2,27 +2,27 @@ import axios from 'axios';
 import { useUser } from './useUser';
 import { useNovelIdData } from '../context/convertDataContext';
 import { Script } from '../types';
+import { useAuth } from './useAuth';
+import { useAxiosInstances } from './useAxiosInstance';
 
 export const useConvert = () => {
   const { getTokenUser } = useUser();
   const { novelId } = useNovelIdData();
+  const { reissue } = useAuth();
+
+  // axios instance 선언
+  const { createAxiosInstance } = useAxiosInstances();
+  const axiosInstance = createAxiosInstance(reissue);
 
   // api: save novel / spring
   const saveNovel = async (title: string, novel: string) => {
-    const { accessToken } = getTokenUser();
-    const headers = {
-      'X-AUTH-TOKEN': accessToken,
-    };
-
     const requestData = {
       title: title,
       novel: novel,
     };
 
     try {
-      const result = await axios.post(`/spring/novels`, requestData, {
-        headers: headers,
-      });
+      const result = await axiosInstance.post(`/spring/novels`, requestData);
       const data = result.data;
       return data;
     } catch (err) {
@@ -45,23 +45,15 @@ export const useConvert = () => {
 
   // api: convert a script / spring
   const convertScript = async (candidates: string[], text: string) => {
-    const { accessToken } = getTokenUser();
-    const headers = {
-      'X-AUTH-TOKEN': accessToken,
-    };
-
     const requestData = {
       candidates: candidates,
       text: text,
     };
 
     try {
-      const result = await axios.post(
+      const result = await axiosInstance.post(
         `/spring/scripts/${novelId}`,
-        requestData,
-        {
-          headers: headers,
-        }
+        requestData
       );
 
       const data = result.data;
@@ -80,11 +72,6 @@ export const useConvert = () => {
 
   // api: convert storyboard
   const convertStoryboard = async (scriptId: number, script: Script) => {
-    const { accessToken } = getTokenUser();
-    const headers = {
-      'X-AUTH-TOKEN': accessToken,
-    };
-
     const requestData = {
       scriptId: scriptId,
       script: script,
@@ -93,10 +80,7 @@ export const useConvert = () => {
     try {
       const result = await axios.post(
         `/spring/sb/generate-storyboard`,
-        requestData,
-        {
-          headers: headers,
-        }
+        requestData
       );
 
       const data = result.data;
@@ -115,17 +99,8 @@ export const useConvert = () => {
 
   // api: create a new chatRoom / spring
   const startNewChat = async (scriptId: number) => {
-    const { accessToken } = getTokenUser();
-    const headers = {
-      'X-AUTH-TOKEN': accessToken,
-    };
-
     try {
-      const result = await axios.post(
-        `/spring/chatRooms/${scriptId}`,
-        {},
-        { headers: headers }
-      );
+      const result = await axios.post(`/spring/chatRooms/${scriptId}`);
 
       const data = result.data;
       console.log(data);
@@ -144,15 +119,8 @@ export const useConvert = () => {
   // api: get chat list / spring
   // (need fix) cursor-based-pagination
   const getChatList = async (chatRoomId: string) => {
-    const { accessToken } = getTokenUser();
-    const headers = {
-      'X-AUTH-TOKEN': accessToken,
-    };
-
     try {
-      const result = await axios.get(`/spring/chats/${chatRoomId}`, {
-        headers: headers,
-      });
+      const result = await axios.get(`/spring/chats/${chatRoomId}`);
 
       const data = result.data;
       if (data.isSuccess) {
@@ -169,17 +137,9 @@ export const useConvert = () => {
 
   // api: apperance rate
   const apperanceRate = async (scriptId: number) => {
-    const { accessToken } = getTokenUser();
-    const headers = {
-      'X-AUTH-TOKEN': accessToken,
-    };
-
     try {
       const result = await axios.get(
-        `/spring/scripts/${scriptId}/appearance-rate`,
-        {
-          headers: headers,
-        }
+        `/spring/scripts/${scriptId}/appearance-rate`
       );
       const data = result.data;
       if (data.isSuccess) {
@@ -195,15 +155,8 @@ export const useConvert = () => {
 
   // api: novel statistics
   const convertStatistics = async (scriptId: number) => {
-    const { accessToken } = getTokenUser();
-    const headers = {
-      'X-AUTH-TOKEN': accessToken,
-    };
-
     try {
-      const result = await axios.get(`/spring/scripts/${scriptId}/details`, {
-        headers: headers,
-      });
+      const result = await axios.get(`/spring/scripts/${scriptId}/details`);
       const data = result.data;
       if (data.isSuccess) {
         return data;

--- a/src/hooks/useConvert.ts
+++ b/src/hooks/useConvert.ts
@@ -100,7 +100,7 @@ export const useConvert = () => {
   // api: create a new chatRoom / spring
   const startNewChat = async (scriptId: number) => {
     try {
-      const result = await axios.post(`/spring/chatRooms/${scriptId}`);
+      const result = await axiosInstance.post(`/spring/chatRooms/${scriptId}`);
 
       const data = result.data;
       console.log(data);
@@ -120,7 +120,7 @@ export const useConvert = () => {
   // (need fix) cursor-based-pagination
   const getChatList = async (chatRoomId: string) => {
     try {
-      const result = await axios.get(`/spring/chats/${chatRoomId}`);
+      const result = await axiosInstance.get(`/spring/chats/${chatRoomId}`);
 
       const data = result.data;
       if (data.isSuccess) {
@@ -138,7 +138,7 @@ export const useConvert = () => {
   // api: apperance rate
   const apperanceRate = async (scriptId: number) => {
     try {
-      const result = await axios.get(
+      const result = await axiosInstance.get(
         `/spring/scripts/${scriptId}/appearance-rate`
       );
       const data = result.data;
@@ -156,7 +156,9 @@ export const useConvert = () => {
   // api: novel statistics
   const convertStatistics = async (scriptId: number) => {
     try {
-      const result = await axios.get(`/spring/scripts/${scriptId}/details`);
+      const result = await axiosInstance.get(
+        `/spring/scripts/${scriptId}/details`
+      );
       const data = result.data;
       if (data.isSuccess) {
         return data;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { ThemeProvider } from 'styled-components';
+import { ModalProvider } from './context/tokenModalContext';
 
 // global-setting
 import { GlobalStyle } from './styles/global';
@@ -15,8 +16,10 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      <App />
+      <ModalProvider>
+        <GlobalStyle />
+        <App />
+      </ModalProvider>
     </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
### ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요.
* 토큰 재발급 API 연결
* axios API 호출 로직 변경: axios intercepter 적용

**동작 테스트 방법은 아래 글에서 확인해주세요!**
**코드 설명은 이슈에 작성하겠습니다**

### 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
* `SceneList.tsx`에 조건문 추가: scene이 없을 경우
* 토큰이 만료되어 로그아웃 처리했을 때 사용자에게 모달 띄우기: `TokenExpireModal.tsx`

### 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 첨부해주세요.
* 토큰 만료해서 강제 로그아웃 후 모달(TokenExpireModal) 띄우고 메인 페이지로 이동하도록 구현하고 싶은데 `TokenExpireModal`은 `<Router>` 태그 밖에 있어서 `useNavigate`를 사용하여 페이지를 이동할 수 없어요. `window.location.href`를 사용하는 방법을 생각하고 있는데 하드코딩이라 배포하면 또 바꿔줘야 돼요. 혹시 좋은 생각 있으면 알려주세요.
* 저는 localhost에서 실행을 확인했어서 스토리보드 ~ 통계는 테스트하지 못했어요. 동작 확인해주시면 감사하겠습니다!

### ➕ 관련 이슈 링크
- #65 

---
### 📝 Assignee를 위한 CheckList
- [x] API가 잘 동작하는지 확인(액세스 토큰 재발급(TOKEN304), 리프레시 토큰 만료로 로그아웃을 해야 할 때(TOKEN404))
