### PR TITLE
[feat] Implement detail page in convert page

### DIFF
--- a/src/component/convert/chat/ChatbotBox.tsx
+++ b/src/component/convert/chat/ChatbotBox.tsx
@@ -11,7 +11,10 @@ import MessageList from './MessageList';
 import { Message } from '../../../types';
 import { CompatClient, IMessage, Stomp } from '@stomp/stompjs';
 import { useConvert } from '../../../hooks/useConvert';
-import { useScriptIdData } from '../../../context/convertDataContext';
+import {
+  useScriptIdData,
+  useChatRoomIdData,
+} from '../../../context/convertDataContext';
 import { Toast } from '../../../styles/ToastStyle';
 import { toastText } from '../../../utils/toastText';
 import { queryKeys } from '../../../utils/queryKeys';
@@ -29,8 +32,8 @@ const ChatbotBox = () => {
   const client = useRef<CompatClient>(); // 채팅 Stomp 클라이언트
   const { startNewChat, getChatList } = useConvert();
   const { scriptId, setScriptId } = useScriptIdData();
+  const { chatRoomId, setChatRoomId } = useChatRoomIdData();
   //setScriptId(14); // ★★★ 테스트용
-  const [chatRoomId, setChatRoomId] = useState<string>('');
   const [scrollHeight, setScrollHeight] = useState<number>(10);
 
   // 채팅 목록 무한스크롤: 커서 기반 페이징
@@ -167,7 +170,11 @@ const ChatbotBox = () => {
 
   // floating button 활성화
   useEffect(() => {
-    if (scriptId !== 0) {
+    if (chatRoomId !== '') {
+      // 이미 채팅방이 존재할 때
+      setChatRoomId(chatRoomId);
+    } else if (scriptId !== 0 && chatRoomId == '') {
+      // 채팅방이 없을 때
       Toast.success(toastText.chatbotEnable);
       startChatHandler();
     }

--- a/src/context/convertDataContext.tsx
+++ b/src/context/convertDataContext.tsx
@@ -38,6 +38,11 @@ type StoryboardContextType = {
   setStoryboard: React.Dispatch<React.SetStateAction<Storyboard>>;
 };
 
+type ChatRoomIdContextType = {
+  chatRoomId: string;
+  setChatRoomId: React.Dispatch<React.SetStateAction<string>>;
+};
+
 type StatisticsContextType = {};
 
 // 전역: 컨택스트 정의
@@ -80,6 +85,11 @@ const StoryboardContext = createContext<StoryboardContextType | undefined>({
   setStoryboard: () => {},
 });
 
+const ChatRoomIdContext = createContext<ChatRoomIdContextType | undefined>({
+  chatRoomId: '',
+  setChatRoomId: () => {},
+});
+
 // 컨택스트를 전역적으로 제공할 수 있는 프로바이더 작성, 컴포넌트 순서 상관X
 const ConvertDataProvider = ({ children }: { children: React.ReactNode }) => {
   const [text, setText] = useState<string>('');
@@ -89,25 +99,28 @@ const ConvertDataProvider = ({ children }: { children: React.ReactNode }) => {
   const [novelId, setNovelId] = useState<string>('');
   const [storyboard, setStoryboard] = useState<Storyboard>({ scene: [] });
   const [scriptId, setScriptId] = useState<number>(0);
+  const [chatRoomId, setChatRoomId] = useState<string>('');
 
   return (
-    <StoryboardContext.Provider value={{ storyboard, setStoryboard }}>
-      <NovelTitleContext.Provider value={{ title, setTitle }}>
-        <NovelContext.Provider value={{ text, setText }}>
-          <CharacterContext.Provider
-            value={{ characterList, setCharacterList }}
-          >
-            <ScriptContext.Provider value={{ script, setScript }}>
-              <ScriptIdContext.Provider value={{ scriptId, setScriptId }}>
-                <NovelIdContext.Provider value={{ novelId, setNovelId }}>
-                  {children}
-                </NovelIdContext.Provider>
-              </ScriptIdContext.Provider>
-            </ScriptContext.Provider>
-          </CharacterContext.Provider>
-        </NovelContext.Provider>
-      </NovelTitleContext.Provider>
-    </StoryboardContext.Provider>
+    <ChatRoomIdContext.Provider value={{ chatRoomId, setChatRoomId }}>
+      <StoryboardContext.Provider value={{ storyboard, setStoryboard }}>
+        <NovelTitleContext.Provider value={{ title, setTitle }}>
+          <NovelContext.Provider value={{ text, setText }}>
+            <CharacterContext.Provider
+              value={{ characterList, setCharacterList }}
+            >
+              <ScriptContext.Provider value={{ script, setScript }}>
+                <ScriptIdContext.Provider value={{ scriptId, setScriptId }}>
+                  <NovelIdContext.Provider value={{ novelId, setNovelId }}>
+                    {children}
+                  </NovelIdContext.Provider>
+                </ScriptIdContext.Provider>
+              </ScriptContext.Provider>
+            </CharacterContext.Provider>
+          </NovelContext.Provider>
+        </NovelTitleContext.Provider>
+      </StoryboardContext.Provider>
+    </ChatRoomIdContext.Provider>
   );
 };
 
@@ -176,6 +189,14 @@ const useStoryboardData = () => {
   return context;
 };
 
+const useChatRoomIdData = () => {
+  const context = useContext(ChatRoomIdContext);
+  if (context === undefined) {
+    throw new Error('ChatRoomIdData must be used within a ConvertDataProvider');
+  }
+  return context;
+};
+
 export {
   ConvertDataProvider,
   useNovelIdData,
@@ -185,4 +206,5 @@ export {
   useScriptIdData,
   useScriptData,
   useStoryboardData,
+  useChatRoomIdData,
 };

--- a/src/hooks/useConvert.ts
+++ b/src/hooks/useConvert.ts
@@ -8,6 +8,7 @@ import {
   useNovelTitleData,
   useScriptData,
   useScriptIdData,
+  useChatRoomIdData,
 } from '../context/convertDataContext';
 import { Script } from '../types';
 import { useAuth } from './useAuth';
@@ -26,6 +27,7 @@ export const useConvert = () => {
   const { setScript } = useScriptData();
   const { setScriptId } = useScriptIdData();
   const { setStep } = useConvertStep();
+  const { setChatRoomId } = useChatRoomIdData();
 
   // axios instance 선언
   const { createAxiosInstance } = useAxiosInstances();
@@ -139,7 +141,6 @@ export const useConvert = () => {
       const result = await axiosInstance.post(`/spring/chatRooms/${scriptId}`);
 
       const data = result.data;
-      console.log(data);
       if (data.isSuccess) {
         console.log(data.message);
         return data.result;
@@ -154,27 +155,30 @@ export const useConvert = () => {
 
   // api: get chat list / spring
   // (need fix) cursor-based-pagination
-  const getChatList = async ({ queryKey, pageParam = '' }: QueryFunctionContext<string[], string>) => {
+  const getChatList = async ({
+    queryKey,
+    pageParam = '',
+  }: QueryFunctionContext<string[], string>) => {
     const [, chatRoomId] = queryKey;
 
-  try {
-    const response = await axios.get(`/spring/chats/${chatRoomId}`, {
-      params: {
-        lastMessageId: pageParam || undefined, // 마지막 메시지 ID를 쿼리 파라미터로 전달
-      },
-    });
+    try {
+      const response = await axios.get(`/spring/chats/${chatRoomId}`, {
+        params: {
+          lastMessageId: pageParam || undefined, // 마지막 메시지 ID를 쿼리 파라미터로 전달
+        },
+      });
 
-    const data = response.data;
-    if (data.isSuccess) {
-      return data;
-    } else {
-      console.log(data.message);
-      return data.false;
+      const data = response.data;
+      if (data.isSuccess) {
+        return data;
+      } else {
+        console.log(data.message);
+        return data.false;
+      }
+    } catch (err) {
+      console.log(err); // temporary error handling
     }
-  } catch (err) {
-    console.log(err); // temporary error handling
-  }
-};
+  };
 
   // api: apperance rate
   const apperanceRate = async (scriptId: number) => {
@@ -255,6 +259,7 @@ export const useConvert = () => {
     setScriptId(0);
     setNovelId('');
     setStep([false, false, false, false]);
+    setChatRoomId('');
   };
 
   return {


### PR DESCRIPTION
### ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요.
* 변환 페이지와 상세 페이지를 하나의 컴포넌트에서 같이 사용할 수 있도록 convertPage를 수정했습니다.

### 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
* 없음

### 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 첨부해주세요.
* 변환 페이지에서 스토리보드 변환까지 완료 -> 뒤로가기를 통해 context 초기화 -> 마이페이지에서 만든 결과물 확인

### ➕ 관련 이슈 링크
- #71

---
### 📝 Assignee를 위한 CheckList
- [x] 변환 페이지일 때 스토리보드까지 변환되는 지 확인
- [x] 마이페이지에서 상세페이지로 이동할 때 오류가 발생하지 않는지 확인, 결과물 잘 뜨는지 확인
- [x] 챗봇 잘 연결됐는지 확인
